### PR TITLE
#32 채팅방에서 나갔을 때 인원이 제대로 체크되지 않는 버그 수정

### DIFF
--- a/src/main/generated/webChat/mapper/ChatUserMapperImpl.java
+++ b/src/main/generated/webChat/mapper/ChatUserMapperImpl.java
@@ -9,7 +9,7 @@ import webChat.dto.ChatUserDto.ChatUserDtoBuilder;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-10-29T18:11:55+0900",
+    date = "2023-11-26T23:22:34+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 11.0.11 (AdoptOpenJDK)"
 )
 @Component

--- a/src/main/java/webChat/rtc/KurentoHandler.java
+++ b/src/main/java/webChat/rtc/KurentoHandler.java
@@ -95,11 +95,11 @@ public class KurentoHandler extends TextWebSocketHandler {
     }
 
     // 유저의 연결이 끊어진 경우
-    // 참여자 목록에서 유저 제거
+    // leaveRoom 실행
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
         KurentoUserSession user = registry.removeBySession(session);
-//        roomManager.getRoom(user.getRoomName()).leave(user);
+        this.leaveRoom(user);
     }
 
     // 유저가 Room 에 입장했을 때
@@ -121,16 +121,23 @@ public class KurentoHandler extends TextWebSocketHandler {
 
     // 유저가 room 에서 떠났을 때
     private void leaveRoom(KurentoUserSession user) throws IOException {
-        if (Objects.nonNull(user)) {
-            // 유저명을 기준으로 room 을 가져온다
-            final KurentoRoomDto room = roomManager.getRoom(user.getRoomName());
-
-            // room 에서 유저를 제거하고
-            room.leave(user);
-
-            // room 에서 userCount -1
-            room.setUserCount(room.getUserCount()-1);
+        // user 가 null 이면 return
+        if (Objects.isNull(user)) {
+            return;
         }
+
+        final KurentoRoomDto room = roomManager.getRoom(user.getRoomName());
+
+        // 유저가 room 의 participants 에 없다면 return
+        if (!room.getParticipants().contains(user)) {
+            return;
+        }
+
+        // room 에서 유저를 제거하고
+        room.leave(user);
+
+        // room 에서 userCount -1
+        room.setUserCount(room.getUserCount()-1);
     }
 
     private void connectException(KurentoUserSession user, Exception e) throws IOException {


### PR DESCRIPTION
원인 
- leaveRoom 과 afterConnectionClosed 이벤트 발생 시 room 에서 user 를 제거하는 이벤트와 participants map 에서 유저를 제거하는 이벤트가 없어서 발생하는 문제

수정 
- leaveRoom 과 afterConnectionClosed 이벤트 발생 시 room 에서 user 를 제거하는 이벤트와 participants map 에서 유저를 제거하는 코드 추가.
- 특히 leaveRoom 이벤트에서 user 객체의 null 여부와 participants 에서 user 가 있는지 검사 후 이벤트 실행하도록 코드 수정