### PR TITLE
#50 bug:: 특정 아이피가 아닌 모든 IP 에서 중요 정보에 접근 가능한 문제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,9 @@ dependencies {
 	// https://mvnrepository.com/artifact/io.minio/minio
 	implementation group: 'io.minio', name: 'minio', version: '8.5.7'
 
+	// https://mvnrepository.com/artifact/commons-net/commons-net
+	implementation group: 'commons-net', name: 'commons-net', version: '3.11.1'
+
 
 }
 

--- a/src/main/java/webChat/config/SecurityConfig.java
+++ b/src/main/java/webChat/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import webChat.controller.ExceptionController;
 import webChat.service.social.PrincipalOauth2UserService;
+import webChat.utils.SubnetUtil;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -79,21 +80,9 @@ public class SecurityConfig {
 
             // 허용된 IP 또는 서브넷인지 확인
             boolean isAllowed = allowedIpAddresses.contains(remoteAddr) ||
-                    allowedSubnet.stream().anyMatch(subnet -> isInSubnet(remoteAddr, subnet));
+                    allowedSubnet.stream().anyMatch(subnet -> SubnetUtil.isInRange(subnet, remoteAddr));
 
             return new AuthorizationDecision(isAllowed);
         };
-    }
-
-    /**
-     * IP가 특정 서브넷에 속하는지 확인하는 메서드
-     * @param ip 클라이언트 IP
-     * @param subnet 서브넷
-     * @return 서브넷에 포함 여부
-     */
-    private boolean isInSubnet(String ip, String subnet) {
-        // Apache Commons Net의 SubnetUtils 또는 다른 라이브러리를 사용하여 서브넷 검사를 구현
-        // 예시: return new SubnetUtils(subnet).getInfo().isInRange(ip);
-        return true; // 실제 서브넷 검사를 구현해야 합니다.
     }
 }

--- a/src/main/java/webChat/service/chat/ChatServiceMain.java
+++ b/src/main/java/webChat/service/chat/ChatServiceMain.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import webChat.controller.ExceptionController;
 import webChat.dto.room.ChatRoomDto;
@@ -33,6 +34,9 @@ public class ChatServiceMain {
     // 사이트 통계를 위한 서비스
     private final AnalysisService analysisService;
 
+    @Value("${chatforyou.room.max_user_count}")
+    private int MAX_USER_COUNT;
+
 
     // 전체 채팅방 조회
     public List<ChatRoomDto> findAllRoom() {
@@ -51,6 +55,10 @@ public class ChatServiceMain {
 
     // roomName 로 채팅방 만들기
     public ChatRoomDto createChatRoom(String roomName, String roomPwd, boolean secretChk, int maxUserCnt, String chatType) {
+        // TODO chatroom list 코드를 정리하면서 예외 처리 필요
+        if(maxUserCnt > MAX_USER_COUNT) {
+            throw new ExceptionController.BadRequestException("cant not over max user count : " + maxUserCnt);
+        }
 
         ChatRoomDto room;
 

--- a/src/main/java/webChat/service/chat/KurentoManager.java
+++ b/src/main/java/webChat/service/chat/KurentoManager.java
@@ -72,7 +72,7 @@ public class KurentoManager {
     // rooms 에서 room 객체 삭제 => 이때 room 의 Name 을 가져와서 조회 후 삭제
     this.rooms.remove(room.getRoomId());
 
-    // room 을 종료?
+    // room 을 종료
     room.close();
 
     log.info("Room {} removed and closed", room.getRoomId());

--- a/src/main/java/webChat/utils/SubnetUtil.java
+++ b/src/main/java/webChat/utils/SubnetUtil.java
@@ -1,0 +1,22 @@
+package webChat.utils;
+
+import org.apache.commons.net.util.SubnetUtils;
+
+public class SubnetUtil {
+
+    /**
+     * cidr 에 ip 가 속해있는지 검사
+     * @param cidr 확인 cidr
+     * @param ip 요청받은 ip
+     * @return 포함되면 true, 아니면 false
+     */
+    public static boolean isInRange(String cidr, String ip) {
+        try {
+            SubnetUtils subnetUtils = new SubnetUtils(cidr);
+            subnetUtils.setInclusiveHostCount(true);
+            return subnetUtils.getInfo().isInRange(ip);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/static/js/roomlist/roomlist.js
+++ b/src/main/resources/static/js/roomlist/roomlist.js
@@ -195,8 +195,8 @@ function createRoom() {
             alert("일반 채팅은 최대 100명 입니다!")
             resetEvent();
             return false;
-        } else if ($chatType === 'rtcChat' && $maxUserCnt > 4) {
-            alert("4명 이상은 서버가 아파해요ㅠ.ㅠ");
+        } else if ($chatType === 'rtcChat' && $maxUserCnt > 6) {
+            alert("6명 이상은 서버가 아파해요ㅠ.ㅠ");
             resetEvent();
             return false;
         }


### PR DESCRIPTION
- subnetutil 를 이용해 ip 및 cidr 확인 처리
- chatroom 생성 시 max user count 를 4 -> 6 으로 변경
-> 추후 #51 에서 개발하며 예외처리 추가 필요

## Summary by Sourcery

IP 범위 확인을 라이브러리로 구현하고 채팅방의 최대 사용자 수를 4명에서 6명으로 늘렸습니다.

새로운 기능:
- 채팅방의 최대 사용자 수를 제한하는 기능을 추가했습니다.

버그 수정:
- 특정 IP 대신 모든 IP에서 중요 정보에 접근할 수 있던 문제를 해결했습니다.

개선 사항:
- 사용자 정의 IP 범위 확인 로직을 `commons-net` 라이브러리로 대체했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement IP range checking using a library and increase the maximum number of users in a chat room from 4 to 6.

New Features:
- Added a feature to limit the maximum number of users in a chat room.

Bug Fixes:
- Fixed an issue where critical information was accessible from any IP instead of specific IPs.

Enhancements:
- Replaced custom IP range checking logic with the `commons-net` library.

</details>