### PR TITLE
#56 기존 chatforyou 에서 사용되었던 일부 기능들이 동작하지 않는 문제 2차

### DIFF
--- a/nodejs-frontend/static/js/roomlist/roomlist.js
+++ b/nodejs-frontend/static/js/roomlist/roomlist.js
@@ -50,7 +50,7 @@ $(function () {
       $('#confirmPwdModal').modal('show');
     });
     // 비밀방 모달에서 '입장하기' 버튼 클릭 시 enterRoom()이 정확히 호출되는지 보장
-    $(document).off('click', '#enterRoomModal .btn-primary').on('click', '#enterRoomModal .btn-primary', function(e) {
+    $('#enterRoomModal .btn-primary').off('click').on('click', function(e) {
       e.preventDefault();
       enterRoom();
     });

--- a/nodejs-frontend/static/js/roomlist/roomlist.js
+++ b/nodejs-frontend/static/js/roomlist/roomlist.js
@@ -33,12 +33,14 @@ $(function () {
   // 2. 각 방 이벤트 동적 바인딩
   function bindRoomEvents() {
     // 비밀방 입장
-    $('.enterRoomBtn').off('click').on('click', function() {
+    $('.enterRoomBtn').off('click').on('click', function(e) {
+      e.preventDefault();
       roomId = $(this).data('id');
       $('#enterRoomModal').modal('show');
     });
     // 일반방 바로 입장
-    $('.directEnterBtn').off('click').on('click', function() {
+    $('.directEnterBtn').off('click').on('click', function(e) {
+      e.preventDefault();
       const id = $(this).data('roomid');
       chkRoomUserCnt(id);
     });
@@ -46,6 +48,11 @@ $(function () {
     $('.configRoomBtn').off('click').on('click', function() {
       roomId = $(this).data('id');
       $('#confirmPwdModal').modal('show');
+    });
+    // 비밀방 모달에서 '입장하기' 버튼 클릭 시 enterRoom()이 정확히 호출되는지 보장
+    $(document).off('click', '#enterRoomModal .btn-primary').on('click', '#enterRoomModal .btn-primary', function(e) {
+      e.preventDefault();
+      enterRoom();
     });
   }
 
@@ -193,12 +200,32 @@ $(function () {
     myModal.show();
   });
 
-  // 방 생성 모달 submit 이벤트
+  // 방 생성 모달 닫힐 때 input 값 초기화
+  $('#roomModal').on('hidden.bs.modal', function () {
+    $('#modalRoomName').val('');
+    $('#modalRoomPwd').val('');
+    $('#modalMaxUserCnt').val('2');
+  });
+
+  // 방 생성 최대 인원 입력 제한 (2~6)
+  $(document).on('input', '#modalMaxUserCnt', function() {
+    let val = parseInt($(this).val(), 10);
+    if (isNaN(val) || val < 2) {
+      $(this).val(2);
+    } else if (val > 6) {
+      $(this).val(6);
+    }
+  });
+
+  // 방 생성 submit 시 최대 인원 2~6만 허용
   $('#modalCreateRoomForm').off('submit').on('submit', function(e) {
     e.preventDefault();
     const name = $('#modalRoomName').val();
     const pwd = $('#modalRoomPwd').val();
-    const maxUserCnt = $('#modalMaxUserCnt').val();
+    let maxUserCnt = parseInt($('#modalMaxUserCnt').val(), 10);
+    if (isNaN(maxUserCnt) || maxUserCnt < 2) maxUserCnt = 2;
+    if (maxUserCnt > 6) maxUserCnt = 6;
+    $('#modalMaxUserCnt').val(maxUserCnt);
     const secret = $('#modalSecret').is(':checked');
     const chatType = $('input[name="modalChatType"]:checked').val();
     if (!name || !pwd || !maxUserCnt || !chatType) {
@@ -263,14 +290,111 @@ $(function () {
       }).showToast();
       return;
     }
-    // 실제 설정 페이지가 있다면 아래 주석 해제
-    // window.location.href = '/chat/room/config/' + roomId;
-    // 별도 설정 페이지가 없다면 아래처럼 토스트만 띄우고 모달 닫기
     Toastify({
       text: '설정 진입 성공', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#51cf66', close: true
     }).showToast();
     $('#confirmPwdModal').modal('hide');
+    // 실제 설정 모달 띄우기
+    setTimeout(function() {
+      $('#roomConfigModal').modal('show');
+    }, 500);
   });
+
+  // roomConfigModal 열릴 때 현재 방 정보로 input 초기화
+  $('#roomConfigModal').on('show.bs.modal', function () {
+    if (!roomId) return;
+    $.ajax({
+      url: window.__CONFIG__.API_BASE_URL + '/chat/room/' + roomId,
+      type: 'GET',
+      success: function(res) {
+        if (res && res.data) {
+          $('#configRoomName').val(res.data.roomName);
+          $('#configMaxUserCnt').val(res.data.maxUserCnt);
+          $('#configRoomPwd').val(res.data.roomPwd).prop('readonly', true);
+          $('#changePwdCheckbox').prop('checked', false);
+        }
+      }
+    });
+  });
+
+  // 비밀번호 변경 체크박스 토글 시 input 활성화/비활성화
+  $(document).off('change', '#changePwdCheckbox').on('change', '#changePwdCheckbox', function() {
+    if ($(this).is(':checked')) {
+      $('#configRoomPwd').prop('readonly', false).val('');
+    } else {
+      // 기존 비밀번호로 복원 (모달이 열릴 때 ajax로 세팅됨)
+      $('#configRoomPwd').prop('readonly', true);
+      // 값은 그대로 두거나, 필요시 다시 ajax로 불러와도 됨
+    }
+  });
+
+  // 방 수정(modify) 저장 버튼 클릭 시
+  $(document).off('click', '#saveRoomConfigBtn').on('click', '#saveRoomConfigBtn', function() {
+    const name = $('#configRoomName').val().trim();
+    const maxUserCnt = parseInt($('#configMaxUserCnt').val(), 10);
+    const pwd = $('#configRoomPwd').val();
+    const changePwd = $('#changePwdCheckbox').is(':checked');
+    if (!name) {
+      Toastify({ text: '방 이름을 입력하세요.', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#fa5252', close: true }).showToast();
+      return;
+    }
+    if (isNaN(maxUserCnt) || maxUserCnt < 2 || maxUserCnt > 6) {
+      Toastify({ text: '최대 인원은 2~6명만 가능합니다.', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#fa5252', close: true }).showToast();
+      return;
+    }
+    if (changePwd && !pwd) {
+      Toastify({ text: '비밀번호를 입력하세요.', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#fa5252', close: true }).showToast();
+      return;
+    }
+    // 실제 수정 ajax
+    $.ajax({
+      url: window.__CONFIG__.API_BASE_URL + '/chat/room/modify/' + roomId,
+      type: 'PATCH',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        roomId: roomId,
+        roomName: name,
+        maxUserCnt: maxUserCnt,
+        roomPwd: changePwd ? pwd : undefined
+      }),
+      success: function(res) {
+        Toastify({ text: '설정이 저장되었습니다.', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#51cf66', close: true }).showToast();
+        $('#roomConfigModal').modal('hide');
+        window.loadRoomList();
+      },
+      error: function(err) {
+        Toastify({ text: '설정 저장 실패', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#fa5252', close: true }).showToast();
+      }
+    });
+    // input 값 초기화
+    $('#configRoomName').val('');
+    $('#configMaxUserCnt').val('2');
+    $('#configRoomPwd').val('').prop('readonly', true);
+    $('#changePwdCheckbox').prop('checked', false);
+  });
+
+  // 방 삭제 함수(modify) - window.loadRoomList로 호출
+  function delRoom() {
+    let url = window.__CONFIG__.API_BASE_URL + "/chat/room/modify/" + roomId;
+    let successCallback = function (result) {
+      if (result && result.data) {
+        Toastify({ text: '방 삭제를 완료했습니다', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#51cf66', close: true }).showToast();
+        $('#roomConfigModal').modal('hide');
+        window.loadRoomList();
+      } else {
+        Toastify({ text: '방 삭제에 실패했습니다.', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#fa5252', close: true }).showToast();
+      }
+    };
+    let errorCallback = function(error){
+      let result = error.responseJSON;
+      let errorMessage = '방 삭제 중 오류가 발생했습니다.';
+      if (result && result.code === '40041') {
+        errorMessage = result.message;
+      }
+      Toastify({ text: errorMessage, duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#fa5252', close: true }).showToast();
+    }
+    ajax(url, 'DELETE', false, '', successCallback, errorCallback);
+  }
 })
 
 // 채팅방 설정 시 비밀번호 확인 - keyup 펑션 활용
@@ -428,34 +552,14 @@ function enterRoom() {
   ajax(url, 'POST', false, data, successCallback, errorCallback);
 }
 
-// 채팅방 삭제
-function delRoom() {
-  let url = window.__CONFIG__.API_BASE_URL + "/chat/delRoom/" + roomId;
-  let successCallback = function (result) {
-    if (result && result.data) {
-      alert("방 삭제를 완료했습니다");
-      location.href = "/";
-    } else {
-      alert("방 삭제에 실패했습니다.");
-    }
-  };
-  let errorCallback = function(error){
-    let result = error.responseJSON;
-    let errorMessage = '방 삭제 중 오류가 발생했습니다.';
-    if (result && result.code === '40041') {
-      errorMessage = result.message;
-    }
-    alert(errorMessage);
-  }
-  ajax(url, 'DELETE', false, '', successCallback, errorCallback);
-}
-
 // 채팅방 입장 시 인원 수에 따라서 입장 여부 결정
 function chkRoomUserCnt(roomId) {
   let url = window.__CONFIG__.API_BASE_URL + '/chat/chkUserCnt/' + roomId;
   let successCallback = function (result) {
     if (!result || !result.data) {
-      alert("채팅방이 꽉 차서 입장 할 수 없습니다");
+      Toastify({
+        text: '채팅방이 꽉 차서 입장 할 수 없습니다', duration: 2500, gravity: 'top', position: 'center', backgroundColor: '#fa5252', close: true
+      }).showToast();
       return;
     }
     location.href = '/kurentoroom.html?roomId=' + roomId;
@@ -465,3 +569,6 @@ function chkRoomUserCnt(roomId) {
   }
   ajax(url, 'GET', 'false', '', successCallback, errorCallback);
 }
+
+// 방 리스트 동적 렌더링 함수 전역화
+window.loadRoomList = loadRoomList;

--- a/nodejs-frontend/static/js/roomlist/roomlist.js
+++ b/nodejs-frontend/static/js/roomlist/roomlist.js
@@ -293,11 +293,11 @@ $(function () {
     Toastify({
       text: '설정 진입 성공', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#51cf66', close: true
     }).showToast();
-    $('#confirmPwdModal').modal('hide');
-    // 실제 설정 모달 띄우기
-    setTimeout(function() {
+    // #roomConfigModal을 #confirmPwdModal이 완전히 닫힌 후에 띄우기
+    $('#confirmPwdModal').one('hidden.bs.modal', function () {
       $('#roomConfigModal').modal('show');
-    }, 500);
+    });
+    $('#confirmPwdModal').modal('hide');
   });
 
   // roomConfigModal 열릴 때 현재 방 정보로 input 초기화

--- a/nodejs-frontend/static/js/rtc/kurento-service.js
+++ b/nodejs-frontend/static/js/rtc/kurento-service.js
@@ -180,26 +180,21 @@ ws.onmessage = function (message) {
 }
 
 function register() {
-    // kurentoroom.html 진입 시 sessionStorage에서 방/유저 정보 읽기
+    // kurentoroom.html 진입 시 서버에서 방/유저 정보 조회
     let kurentoRoomInfo = null;
     try {
         // 방 정보를 서버에서 조회
-        const url = window.__CONFIG__.API_BASE_URL + '/chat/room?roomId=' + new URLSearchParams(window.location.search).get('roomId');
+        const url = window.__CONFIG__.API_BASE_URL + '/chat/room/' + new URLSearchParams(window.location.search).get('roomId');
         const successCallback = (result) => {
             if (result?.data) {
-                sessionStorage.setItem('kurentoRoomInfo', JSON.stringify(result.data));
+                kurentoRoomInfo = result.data;
             }
         };
         const errorCallback = (error) => {
             console.error('방 정보 조회 실패:', error);
         };
-        
         // AJAX 요청 실행
         ajax(url, 'GET', false, '', successCallback, errorCallback);
-        
-        // sessionStorage에서 방 정보 파싱
-        kurentoRoomInfo = JSON.parse(sessionStorage.getItem('kurentoRoomInfo'));
-        
         // 방 정보가 있으면 필요한 데이터 할당
         if (kurentoRoomInfo) {
             userId = kurentoRoomInfo.userId || kurentoRoomInfo.uuid;
@@ -214,7 +209,6 @@ function register() {
 
     document.getElementById('room-header').innerText = 'ROOM ' + roomName;
     document.getElementById('room').style.display = 'block';
-
 
     let message = {
         id: 'joinRoom',

--- a/nodejs-frontend/templates/roomlist.html
+++ b/nodejs-frontend/templates/roomlist.html
@@ -70,7 +70,7 @@
           </div>
           <div class="mb-3">
             <label for="modalMaxUserCnt" class="form-label">최대 인원 <span class="text-danger">*</span></label>
-            <input type="number" id="modalMaxUserCnt" placeholder="2~6" min="2" max="100" required class="form-control">
+            <input type="number" id="modalMaxUserCnt" placeholder="2~6" min="2" max="6" required class="form-control">
           </div>
           <div class="form-check mb-2">
             <input type="checkbox" id="modalSecret" class="form-check-input">
@@ -126,6 +126,44 @@
       </div>
       <div class="modal-footer">
         <button aria-disabled="true" class="btn btn-primary disabled" id="configRoomBtn">채팅방 설정하기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 채팅방 실제 설정 모달 -->
+<div class="modal fade" id="roomConfigModal" tabindex="-1" aria-labelledby="roomConfigModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="roomConfigModalLabel">채팅방 설정</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="roomConfigForm">
+          <div class="mb-3">
+            <label for="configRoomName" class="form-label">채팅방 이름</label>
+            <input type="text" class="form-control" id="configRoomName" name="configRoomName" placeholder="채팅방 이름">
+          </div>
+          <div class="mb-3">
+            <label for="configMaxUserCnt" class="form-label">최대 인원 (2~6명)</label>
+            <input type="number" class="form-control" id="configMaxUserCnt" name="configMaxUserCnt" min="2" max="6" step="1">
+          </div>
+          <div class="mb-3">
+            <label for="configRoomPwd" class="form-label">비밀번호</label>
+            <div class="input-group">
+              <input type="password" class="form-control" id="configRoomPwd" name="configRoomPwd" placeholder="비밀번호" readonly>
+              <span class="input-group-text">
+                <input type="checkbox" id="changePwdCheckbox" style="margin-top:0.2em;"> <label for="changePwdCheckbox" style="margin-bottom:0;margin-left:0.5em;">비밀번호 변경</label>
+              </span>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+        <button type="button" class="btn btn-danger" id="deleteRoomBtn">방 삭제</button>
+        <button type="button" class="btn btn-primary" id="saveRoomConfigBtn">저장</button>
       </div>
     </div>
   </div>

--- a/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
+++ b/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
@@ -64,11 +64,12 @@ public class ChatRoomController {
         return ResponseEntity.ok(ChatForYouResponse.ofCreateRoom(room));
     }
 
-    // 채팅방 입장 화면
-    // 파라미터로 넘어오는 roomId 를 확인후 해당 roomId 를 기준으로
-    // 채팅방을 찾아서 클라이언트를 chatroom 으로 보낸다.
-    @GetMapping("/room")
-    public ResponseEntity<ChatForYouResponse> roomDetail(Model model, String roomId, @AuthenticationPrincipal PrincipalDetails principalDetails){
+    // 채팅방 정보 확인
+    @GetMapping("/room/{roomId}")
+    public ResponseEntity<ChatForYouResponse> roomDetail(
+            Model model,
+            @PathVariable String roomId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails){
 
         log.info("roomId {}", roomId);
 
@@ -103,8 +104,19 @@ public class ChatRoomController {
                 .build());
     }
 
+    // 채팅방 수정
+    @PatchMapping("/room/{roomId}")
+    public ResponseEntity<ChatForYouResponse> modifyChatRoom(
+            @PathVariable String roomId,
+            @RequestBody ChatRoomDto roomDto){
+        return ResponseEntity.ok(ChatForYouResponse.builder()
+                .result("success")
+                .data(chatServiceMain.chkRoomUserCnt(roomId))
+                .build());
+    }
+
     // 채팅방 삭제
-    @DeleteMapping("/{roomId}")
+    @DeleteMapping("/room/{roomId}")
     public ResponseEntity<ChatForYouResponse> delChatRoom(@PathVariable String roomId){
 
         // roomId 기준으로 chatRoomMap 에서 삭제, 해당 채팅룸 안에 있는 사진 삭제

--- a/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
+++ b/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
@@ -105,13 +105,13 @@ public class ChatRoomController {
     }
 
     // 채팅방 수정
-    @PatchMapping("/room/{roomId}")
+    @PostMapping("/room/modify/{roomId}")
     public ResponseEntity<ChatForYouResponse> modifyChatRoom(
             @PathVariable String roomId,
             @RequestBody ChatRoomDto roomDto){
         return ResponseEntity.ok(ChatForYouResponse.builder()
                 .result("success")
-                .data(chatServiceMain.chkRoomUserCnt(roomId))
+                .data(chatServiceMain.updateRoom(roomId, roomDto.getRoomName(), roomDto.getRoomPwd(), roomDto.getMaxUserCnt()))
                 .build());
     }
 

--- a/springboot-backend/src/main/java/webChat/service/chat/ChatServiceMain.java
+++ b/springboot-backend/src/main/java/webChat/service/chat/ChatServiceMain.java
@@ -133,4 +133,13 @@ public class ChatServiceMain {
             throw new ExceptionController.DelRoomException("DelRoom Exception");
         }
     }
+
+    // 채팅방 수정
+    public ChatRoomDto updateRoom(String roomId, String roomName, String roomPwd, int maxUserCnt) {
+        ChatRoomDto room = ChatRoomMap.getInstance().getChatRooms().get(roomId);
+        room.setRoomName(roomName);
+        room.setRoomPwd(roomPwd);
+        room.setMaxUserCnt(maxUserCnt);
+        return room;
+    }
 }

--- a/springboot-backend/src/main/java/webChat/service/monitoring/impl/MonitoringServiceImpl.java
+++ b/springboot-backend/src/main/java/webChat/service/monitoring/impl/MonitoringServiceImpl.java
@@ -96,26 +96,56 @@ public class MonitoringServiceImpl implements MonitoringService,HandlerIntercept
         }
     }
 
-    private void printRequestInfo(HttpServletRequest request){
+    private void printRequestInfo(HttpServletRequest request) {
         log.info("##########################################");
+        log.info("📍 기본 정보");
         log.info("Remote ipAddrs ::: " + request.getRemoteAddr());
         log.info("Remote Host ipAddrs ::: " + request.getRemoteHost());
 
-        // 모든 HTTP 헤더 출력
-        log.info("========== HTTP Headers ==========");
+        // 🌟 nginx에서 추가한 새로운 디버깅용 헤더들
+        log.info("========== 🔍 nginx 디버깅 헤더들 ==========");
+        log.info("X-Original-IP: {}", request.getHeader("X-Original-IP"));           // nginx에서 보는 원본 IP
+        log.info("X-Generated-Forwarded: {}", request.getHeader("X-Generated-Forwarded")); // nginx에서 생성한 X-Forwarded-For
+        log.info("X-Client-IP: {}", request.getHeader("X-Client-IP"));               // 계산된 클라이언트 IP
+
+        // 기존 nginx 헤더들
+        log.info("========== 🌐 기존 nginx 헤더들 ==========");
+        log.info("X-Real-IP: {}", request.getHeader("X-Real-IP"));
+        log.info("X-Forwarded-For: {}", request.getHeader("X-Forwarded-For"));
+        log.info("X-Forwarded-Proto: {}", request.getHeader("X-Forwarded-Proto"));
+        log.info("Host: {}", request.getHeader("Host"));
+
+        // 🎯 문제 해결 상태 체크
+        log.info("========== 🎯 문제 해결 상태 체크 ==========");
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        String xRealIp = request.getHeader("X-Real-IP");
+        String remoteAddr = request.getRemoteAddr();
+
+        if (xForwardedFor != null && !xForwardedFor.equals("null") && !xForwardedFor.startsWith("10.244.")) {
+            log.info("✅ 성공: X-Forwarded-For에 실제 외부 IP가 전달됨!");
+        } else {
+            log.info("❌ 실패: X-Forwarded-For가 여전히 문제 있음");
+        }
+
+        if (!xRealIp.startsWith("10.244.")) {
+            log.info("✅ 성공: X-Real-IP에 실제 외부 IP가 전달됨!");
+        } else {
+            log.info("❌ 실패: X-Real-IP가 여전히 클러스터 내부 IP");
+        }
+
+        // 🔍 IP 변화 감지
+        log.info("========== 📊 IP 변화 감지 ==========");
+        log.info("Remote Address: {} | X-Real-IP: {} | X-Forwarded-For: {}",
+                remoteAddr, xRealIp, xForwardedFor);
+
+        // 모든 HTTP 헤더 출력 (기존 유지)
+        log.info("========== 📋 모든 HTTP Headers ==========");
         Enumeration<String> headerNames = request.getHeaderNames();
         while (headerNames.hasMoreElements()) {
             String headerName = headerNames.nextElement();
             String headerValue = request.getHeader(headerName);
             log.info("Header: {} = {}", headerName, headerValue);
         }
-
-        // nginx에서 설정한 특정 헤더들 별도 출력
-        log.info("========== Nginx Headers ==========");
-        log.info("X-Real-IP: {}", request.getHeader("X-Real-IP"));
-        log.info("X-Forwarded-For: {}", request.getHeader("X-Forwarded-For"));
-        log.info("X-Forwarded-Proto: {}", request.getHeader("X-Forwarded-Proto"));
-        log.info("Host: {}", request.getHeader("Host"));
 
         log.info("##########################################");
     }


### PR DESCRIPTION
기존 chatforyou 에서 사용되었던 일부 기능들이 동작하지 않는 문제 2차

1. 채팅 방 생성 및 수정 Modal 이벤트 수정 
2. 채팅 방 수정 및 삭제 API 기능 미동작 버그 수정
3. 방 입장 시 2번 이상 클릭해야했던 버그 수정

## Sourcery 요약

이벤트 바인딩 업데이트, 입력 제약 조건 적용, 생성/편집/삭제 기능 복원을 통해 손상된 채팅방 기능을 수정합니다. 인라인 방 설정 모달과 해당 백엔드 수정 사항을 추가하고, 방 정보 검색을 간소화하고 디버깅을 위한 로깅을 개선합니다.

새로운 기능:
- 채팅방 편집 및 삭제를 위한 새로운 방 설정 모달을 통해 인라인 방 구성 활성화
- 채팅방 수정을 위한 백엔드에 PATCH 엔드포인트 도입

버그 수정:
- 기본 클릭 동작을 방지하여 방 입장 버튼에서 더블 클릭해야 하는 문제 수정
- submit 및 click 이벤트 재바인딩을 통해 방 생성 및 수정 모달 기능 복원
- sessionStorage 대신 API에서 가져와 kurento 서비스에서 올바른 방 정보 검색

개선 사항:
- 클라이언트 폼 입력 및 제출 시 방 최대 사용자 수 (2–6) 적용 및 유효성 검사
- 일관된 UX를 위해 기본 경고를 Toastify 알림으로 대체
- 작업 후 더 쉽게 방 목록을 새로 고칠 수 있도록 loadRoomList를 전역 범위에 노출
- 자세한 nginx 헤더 및 IP 유효성 검사로 서버 측 요청 로깅 개선

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix broken chat room features by updating event bindings, enforcing input constraints, and restoring create/edit/delete functionality; add an inline room settings modal and corresponding backend modifications; streamline room info retrieval and improve logging for debugging.

New Features:
- Enable inline room configuration through a new room settings modal for editing and deleting chat rooms
- Introduce a PATCH endpoint on the backend for chat room modifications

Bug Fixes:
- Fix double-click requirement on room entry buttons by preventing default click behavior
- Restore functionality of room creation and modification modals by rebinding submit and click events
- Correct room information retrieval in kurento service by fetching from the API instead of sessionStorage

Enhancements:
- Enforce and validate the room max user count (2–6) on both the client form input and submission
- Replace native alerts with Toastify notifications for a consistent UX
- Expose loadRoomList to the global scope for easier room list refresh after operations
- Enhance server-side request logging with detailed nginx headers and IP validation checks

</details>