### PR TITLE
#62 비밀번호가 걸려있는 채팅방 입장 시 입장불가 버그

### DIFF
--- a/nodejs-frontend/static/js/popup/room_popup.js
+++ b/nodejs-frontend/static/js/popup/room_popup.js
@@ -183,7 +183,7 @@ const RoomPopup = {
         }
 
         let successCallback = function(result) {
-            if (result.data && result.data.confirmPwd) {
+            if (result && result.data && result.result === 'success') {
                 self.showToast('방에 정상적으로 입장했습니다!', 'success');
                 $('#enterRoomModal').modal('hide');
                 location.href = window.__CONFIG__.BASE_URL + '/kurentoroom.html?roomId=' + self.roomId;
@@ -200,7 +200,7 @@ const RoomPopup = {
             }
         };
 
-        const url = window.__CONFIG__.API_BASE_URL + '/chat/room/confirmPwd/' + self.roomId;
+        const url = window.__CONFIG__.API_BASE_URL + '/chat/room/validatePwd/' + self.roomId;
         const requestData = { roomPwd: pwd };
         ajax(url, 'POST', true, requestData, successCallback, errorCallback);
     },
@@ -212,7 +212,7 @@ const RoomPopup = {
         const self = this;
         
         let successCallback = function(result) {
-            if (result.data && result.result === 'success') {
+            if (result && result.data && result.result === 'success') {
                 self.showToast('방에 정상적으로 입장했습니다!', 'success');
                 location.href = window.__CONFIG__.BASE_URL + '/kurentoroom.html?roomId=' + roomId;
             } else {

--- a/nodejs-frontend/static/js/popup/room_settings_popup.js
+++ b/nodejs-frontend/static/js/popup/room_settings_popup.js
@@ -23,12 +23,12 @@ const RoomSettingsPopup = {
         // 방 설정 모달 버튼 클릭
         $(document).off('click', '.configRoomBtn').on('click', '.configRoomBtn', function () {
             self.roomId = $(this).data('id');
-            $('#confirmPwdModal').modal('show');
+            $('#validatePwdModal').modal('show');
         });
 
         // 비밀번호 확인 모달에서 설정하기 버튼 클릭
         $(document).off('click', '#configRoomBtn').on('click', '#configRoomBtn', function () {
-            self.validatePassword($('#confirmPwd').val());
+            self.validatePassword($('#validatePwd').val());
         });
 
         // 방 삭제 버튼 클릭
@@ -61,7 +61,7 @@ const RoomSettingsPopup = {
         });
 
         // 비밀번호 확인 입력 시 설정 버튼 활성화/비활성화
-        $(document).off('input', '#confirmPwd').on('input', '#confirmPwd', function () {
+        $(document).off('input', '#validatePwd').on('input', '#validatePwd', function () {
             const pwd = $(this).val().trim();
             const $configBtn = $('#configRoomBtn');
 
@@ -73,8 +73,8 @@ const RoomSettingsPopup = {
         });
 
         // 비밀번호 확인 모달이 열릴 때 버튼 초기화
-        $(document).off('shown.bs.modal', '#confirmPwdModal').on('shown.bs.modal', '#confirmPwdModal', function () {
-            $('#confirmPwd').val('');
+        $(document).off('shown.bs.modal', '#validatePwdModal').on('shown.bs.modal', '#validatePwdModal', function () {
+            $('#validatePwd').val('');
             $('#configRoomBtn').addClass('disabled').attr('aria-disabled', 'true');
         });
     },
@@ -98,7 +98,7 @@ const RoomSettingsPopup = {
                 $('#changePwdCheckbox').prop('checked', false);
                 $('#configRoomPwd').prop('readonly', true);
 
-                $('#confirmPwdModal').modal('hide');
+                $('#validatePwdModal').modal('hide');
                 $('#roomConfigModal').modal('show');
 
             } else {
@@ -125,7 +125,7 @@ const RoomSettingsPopup = {
         const self = this;
 
         let successCallback = function (result) {
-            if (result && result.result === 'success') {
+            if (result && result.result === 'success' && result.data) {
                 self.loadRoomInfo();
             } else {
                 self.showToast('비밀번호가 일치하지 않습니다.', 'error');

--- a/nodejs-frontend/static/js/roomlist/roomlist.js
+++ b/nodejs-frontend/static/js/roomlist/roomlist.js
@@ -64,7 +64,7 @@ const roomList = {
       const roomId = $(this).data('id');
       if (window.RoomSettingsPopup) {
         window.RoomSettingsPopup.setRoomId(roomId);
-        $('#confirmPwdModal').modal('show');
+        $('#validatePwdModal').modal('show');
       }
     });
     // 방 생성 - RoomPopup으로 위임 (이벤트는 RoomPopup에서 처리됨)
@@ -94,7 +94,7 @@ const roomList = {
       Toastify({
         text: '설정 진입 성공', duration: 2000, gravity: 'top', position: 'center', backgroundColor: '#51cf66', close: true
       }).showToast();
-      $('#confirmPwdModal').modal('hide');
+      $('#validatePwdModal').modal('hide');
       setTimeout(function() {
         $('#roomConfigModal').modal('show');
       }, 500);
@@ -169,7 +169,7 @@ const roomList = {
       self.roomId = $(event.relatedTarget).data('id');
     });
     // 방 설정 모달 열릴 때 roomId 세팅 보강 및 기존 비밀번호 저장
-    $(document).on('show.bs.modal', '#confirmPwdModal', function (e) {
+    $(document).on('show.bs.modal', '#validatePwdModal', function (e) {
       let id = $(e.relatedTarget).data('id');
       if (id) {
         self.roomId = id;
@@ -193,8 +193,8 @@ const roomList = {
       });
     });
     // 비밀번호 확인 모달 닫힐 때 입력값 및 안내 초기화
-    $('#confirmPwdModal').on('hidden.bs.modal', function () {
-      $('#confirmPwd').val('');
+    $('#validatePwdModal').on('hidden.bs.modal', function () {
+      $('#validatePwd').val('');
       $('#confirmLabel').text('비밀번호 확인');
       $('#confirm').remove();
     });

--- a/nodejs-frontend/templates/popup/room_settings_popup.html
+++ b/nodejs-frontend/templates/popup/room_settings_popup.html
@@ -1,14 +1,14 @@
 <!-- 방 설정변경 모달(비밀번호 확인) -->
-<div class="modal fade" id="confirmPwdModal" tabindex="-1" aria-labelledby="confirmPwdModalLabel" aria-hidden="true">
+<div class="modal fade" id="validatePwdModal" tabindex="-1" aria-labelledby="validatePwdModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="confirmPwdModalLabel">채팅방 설정을 위한 패스워드 확인</h5>
+        <h5 class="modal-title" id="validatePwdModalLabel">채팅방 설정을 위한 패스워드 확인</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <label class="col-form-label" for="confirmPwd" id="confirmLabel">비밀번호 확인</label>
-        <input class="form-control" id="confirmPwd" name="confirmPwd" type="password"/>
+        <label class="col-form-label" for="validatePwd" id="confirmLabel">비밀번호 확인</label>
+        <input class="form-control" id="validatePwd" name="validatePwd" type="password"/>
       </div>
       <div class="modal-footer">
         <button aria-disabled="true" class="btn btn-primary disabled" id="configRoomBtn">채팅방 설정하기</button>

--- a/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
+++ b/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
@@ -90,7 +90,7 @@ public class ChatRoomController {
 
     // 채팅방 비밀번호 확인
     @PostMapping(value = "/room/validatePwd/{roomId}")
-    public ResponseEntity<ChatForYouResponse> confirmPwd(
+    public ResponseEntity<ChatForYouResponse> validatePwd(
             @PathVariable String roomId,
             @RequestParam("roomPwd") String roomPwd){
 
@@ -98,7 +98,7 @@ public class ChatRoomController {
         // 찾아서 입력받은 roomPwd 와 room pwd 와 비교해서 맞으면 true, 아니면  false
         return ResponseEntity.ok(ChatForYouResponse.builder()
                 .result("success")
-                .data(chatService.confirmPwd(roomId, roomPwd))
+                .data(chatService.validatePwd(roomId, roomPwd))
                 .build());
     }
 

--- a/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
+++ b/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
@@ -96,6 +96,7 @@ public class ChatRoomController {
 
         // 넘어온 roomId 와 roomPwd 를 이용해서 비밀번호 찾기
         // 찾아서 입력받은 roomPwd 와 room pwd 와 비교해서 맞으면 true, 아니면  false
+        // TODO 추후 401 권한 에러로 수정할 것
         return ResponseEntity.ok(ChatForYouResponse.builder()
                 .result("success")
                 .data(chatService.validatePwd(roomId, roomPwd))

--- a/springboot-backend/src/main/java/webChat/service/chat/ChatService.java
+++ b/springboot-backend/src/main/java/webChat/service/chat/ChatService.java
@@ -81,7 +81,7 @@ public class ChatService {
     }
 
     // 채팅방 비밀번호 조회
-    public boolean confirmPwd(String roomId, String roomPwd) {
+    public boolean validatePwd(String roomId, String roomPwd) {
 //        String pwd = chatRoomMap.get(roomId).getRoomPwd();
         // TODO 방정보 찾을 수 없는 경우 예외처리
         return roomPwd.equals(ChatRoomMap.getInstance().getChatRooms().get(roomId).getRoomPwd());
@@ -146,6 +146,7 @@ public class ChatService {
         room.setRoomName(roomName);
         room.setRoomPwd(roomPwd);
         room.setMaxUserCnt(maxUserCnt);
+        ChatRoomMap.getInstance().getChatRooms().put(roomId, room);
         return room;
     }
 }


### PR DESCRIPTION
1. 비밀번호 확인 api path 변경
2. room update 로직 수정

## Sourcery 요약

프론트엔드 모달, 필드 및 API 호출에서 비밀번호 유효성 검사 흐름을 "confirmPwd"에서 "validatePwd"로 이름을 변경하고 표준화합니다. 백엔드 컨트롤러 및 서비스 메서드를 업데이트하여 새 엔드포인트 경로와 일치시키고, 채팅방 업데이트 로직을 수정하여 메모리 내 룸 맵에 변경 사항을 유지합니다.

버그 수정:
- 프론트엔드를 새로운 validatePwd 모달 및 엔드포인트를 사용하도록 재구성하여 비밀번호로 보호된 방에 올바르게 입장할 수 있도록 합니다.

개선 사항:
- 룸 업데이트 후 ChatRoomMap에 업데이트된 채팅방 세부 정보를 유지합니다.
- 프론트엔드 응답 처리를 강화하여 성공 콜백에서 result.data를 명시적으로 확인합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename and standardize the password validation flow from “confirmPwd” to “validatePwd” across the front-end modals, fields, and API calls, update the backend controller and service methods to match the new endpoint path, and fix the chat room update logic to persist changes in the in-memory room map.

Bug Fixes:
- Enable correct entry into password-protected rooms by rewiring the front-end to use the new validatePwd modal and endpoint.

Enhancements:
- Persist updated chat room details in ChatRoomMap after room updates.
- Tighten front-end response handling to explicitly check for result.data in success callbacks.

</details>