### PR TITLE
#70 방 삭제 batch 동작 안함 :: batch 로직에 방 삭제 로직 추가

### DIFF
--- a/springboot-backend/src/main/java/webChat/batch/RoomBatchJob.java
+++ b/springboot-backend/src/main/java/webChat/batch/RoomBatchJob.java
@@ -27,6 +27,7 @@ public class RoomBatchJob {
     private final AnalysisService analysisService;
     private final DailyInfoRepository dailyInfoRepository;
     private final FileService fileService;
+    private final ChatRoomService chatRoomService;
 
     @Scheduled(cron = "0 0,30 * * * *", zone = "Asia/Seoul") // 매 시간 30분에 실행 , 타임존 seoul 기준
     public void checkRoom() {
@@ -40,7 +41,7 @@ public class RoomBatchJob {
                     KurentoRoom room = (KurentoRoom) chatRooms.get(key);
 
                     if (room.getUserCount() <= 0) { // chatroom 에서 usercount 가 0 이하만 list 에 저장
-                        room.close();
+                        chatRoomService.delChatRoom(room.getRoomId());
                         // room 에서 업로드된 모든 파일 삭제
                         fileService.deleteFileDir(room.getRoomId());
 


### PR DESCRIPTION
## Sourcery 요약

ChatRoomService를 통해 예약된 RoomBatchJob에 방 삭제 기능 추가

버그 수정:
- 빈 채팅방 삭제에 실패하는 배치 작업 수정

개선 사항:
- ChatRoomService를 RoomBatchJob에 주입
- `room.close()` 직접 호출을 `chatRoomService.delChatRoom(roomId)`로 대체

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add room deletion via ChatRoomService to scheduled RoomBatchJob

Bug Fixes:
- Fix batch job failing to delete empty chat rooms

Enhancements:
- Inject ChatRoomService into RoomBatchJob
- Replace direct room.close() call with chatRoomService.delChatRoom(roomId)

</details>