### PR TITLE
#62 비밀번호가 걸려있는 채팅방 입장 시 입장불가 버그 수정

### DIFF
--- a/nodejs-frontend/static/js/rtc/kurento-service.js
+++ b/nodejs-frontend/static/js/rtc/kurento-service.js
@@ -238,7 +238,7 @@ function register() {
         id: 'joinRoom',
         nickName : nickName,
         userId: userId,
-        room: roomId,
+        roomId: roomId,
     }
     sendMessageToServer(message);
 }

--- a/springboot-backend/src/main/java/webChat/config/ShutdownConfig.java
+++ b/springboot-backend/src/main/java/webChat/config/ShutdownConfig.java
@@ -68,7 +68,7 @@ public class ShutdownConfig implements ApplicationListener<ContextClosedEvent> {
 
             // redis 에서 해당 방의 유저수 및 방 상태 변경
             kurentoRoom.setUserCount(0); // 유저 count 초기화
-            kurentoRoom.setRoomState(RoomState.INACTIVE); // 방 상태 초기화
+            kurentoRoom.setRoomState(RoomState.CREATED); // 방 상태 초기화
             redisService.updateChatRoom(kurentoRoom);
             log.info("KurentoRoom {} data updated", kurentoRoom.getRoomId());
 

--- a/springboot-backend/src/main/java/webChat/controller/AdminController.java
+++ b/springboot-backend/src/main/java/webChat/controller/AdminController.java
@@ -63,7 +63,7 @@ public class AdminController {
         }
         List<ChatRoomOutVo> responses = new ArrayList<>();
         chatRoomService.getRoomList("", Integer.parseInt(pageNumStr), Integer.parseInt(pageSizeStr), true).forEach(room -> {
-            responses.add(ChatRoomOutVo.of(room));
+            responses.add(ChatRoomOutVo.ofJoin(room));
         });
         return ResponseEntity.ok(responses);
     }

--- a/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
+++ b/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
@@ -13,7 +13,6 @@ import webChat.model.room.in.ChatRoomInVo;
 import webChat.model.room.out.ChatRoomOutVo;
 import webChat.model.chat.ChatType;
 import webChat.service.chatroom.ChatRoomService;
-import webChat.service.kurento.KurentoRoomManager;
 import webChat.service.social.PrincipalDetails;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +24,6 @@ import java.util.List;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
-    private final KurentoRoomManager kurentoRoomManager;
 
     @GetMapping("/room/list")
     public ResponseEntity<List<ChatRoomOutVo>> goChatRooms(
@@ -44,7 +42,7 @@ public class ChatRoomController {
 //        }
 
 //        model.addAttribute("user", "hey");
-        chatRoomService.getRoomList(keyword, Integer.parseInt(pageNumStr), Integer.parseInt(pageSizeStr), true).forEach(room -> {
+        chatRoomService.getRoomList(keyword, Integer.parseInt(pageNumStr), Integer.parseInt(pageSizeStr), false).forEach(room -> {
             responses.add(ChatRoomOutVo.of(room));
         });
         return ResponseEntity.ok(responses);
@@ -64,7 +62,7 @@ public class ChatRoomController {
         return ResponseEntity.ok(ChatForYouResponse.ofCreateRoom(room));
     }
 
-    // 채팅방 정보 확인
+    // 채팅방 입장
     @GetMapping("/room/{roomId}")
     public ResponseEntity<ChatForYouResponse> roomDetail(
             Model model,

--- a/springboot-backend/src/main/java/webChat/model/response/common/ChatForYouResponse.java
+++ b/springboot-backend/src/main/java/webChat/model/response/common/ChatForYouResponse.java
@@ -30,7 +30,7 @@ public class ChatForYouResponse {
     public static ChatForYouResponse ofJoinRoom(ChatRoom chatRoom) {
         return ChatForYouResponse.builder()
                 .result(SUCCESS_RESULT)
-                .data(ChatRoomOutVo.of(chatRoom))
+                .data(ChatRoomOutVo.ofJoin(chatRoom))
                 .build();
     }
 }

--- a/springboot-backend/src/main/java/webChat/model/room/out/ChatRoomOutVo.java
+++ b/springboot-backend/src/main/java/webChat/model/room/out/ChatRoomOutVo.java
@@ -1,17 +1,23 @@
 package webChat.model.room.out;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 import webChat.model.chat.ChatType;
 import webChat.model.room.ChatRoom;
 import webChat.model.room.RoomState;
+import java.util.Random;
+import java.util.UUID;
 
 // TODO 유저 리스트 추가
 @Builder
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChatRoomOutVo {
     private String roomId; // 채팅방 고유번호
     private String roomName; // 채팅방 이름
+    private String userId; // 유저 고유값
+    private String nickName; // 유저 닉네임
     private int userCount; // 채팅방 인원수
     private int maxUserCnt; // 채팅방 최대 인원 제한
     private String roomPwd; // 채팅방 삭제시 필요한 pwd
@@ -23,6 +29,21 @@ public class ChatRoomOutVo {
         return ChatRoomOutVo.builder()
                 .roomId(chatRoom.getRoomId())
                 .roomName(chatRoom.getRoomName())
+                .userCount(chatRoom.getUserCount())
+                .maxUserCnt(chatRoom.getMaxUserCnt())
+                .roomPwd(chatRoom.getRoomPwd())
+                .secretChk(chatRoom.isSecretChk())
+                .roomType(chatRoom.getChatType())
+                .roomState(chatRoom.getRoomState())
+                .build();
+    }
+
+    public static ChatRoomOutVo ofJoin(ChatRoom chatRoom) {
+        return ChatRoomOutVo.builder()
+                .roomId(chatRoom.getRoomId())
+                .roomName(chatRoom.getRoomName())
+                .userId(UUID.randomUUID().toString().split("-")[0])
+                .nickName("guest" + (new Random().nextInt(100)+1))
                 .userCount(chatRoom.getUserCount())
                 .maxUserCnt(chatRoom.getMaxUserCnt())
                 .roomPwd(chatRoom.getRoomPwd())

--- a/springboot-backend/src/main/java/webChat/service/kurento/KurentoHandler.java
+++ b/springboot-backend/src/main/java/webChat/service/kurento/KurentoHandler.java
@@ -119,7 +119,7 @@ public class KurentoHandler extends TextWebSocketHandler {
     // 유저가 Room 에 입장했을 때
     private void joinRoom(JsonObject params, WebSocketSession session) throws IOException {
         // json 형태의 params 에서 room 과 userId, nickName 을 분리해온다
-        final String roomId = params.get("room").getAsString();
+        final String roomId = params.get("roomId").getAsString();
         final String userId = params.get("userId").getAsString();
         final String nickName = params.get("nickName").getAsString();
 


### PR DESCRIPTION
1.  비밀번호방 입장불가 버그 수정
2. hotfix :: 채팅방 입장 불가 버그 수정

## Sourcery 요약

비밀번호로 보호된 채팅방에 참여할 수 있도록 참여 전용 응답 모델을 추가하고, 컨트롤러 엔드포인트 및 WebSocket 처리를 roomId를 사용하도록 업데이트하며, 프론트엔드 메시지 페이로드를 조정합니다.

버그 수정:
- 새로운 참여 응답 매핑을 사용하여 비밀 채팅방에 입장할 수 있도록 허용합니다.
- WebSocket 핸들러가 "room" 대신 "roomId"를 읽도록 수정합니다.
- 정리 시 Kurento 방 상태를 CREATED로 재설정합니다.

개선 사항:
- userId 및 nickName을 포함하고 null JSON 필드를 제외하는 ChatRoomOutVo.ofJoin을 도입합니다.
- 관리자 및 참여 엔드포인트를 ofJoin 응답 DTO를 사용하도록 전환합니다.
- 참여 전용 페이로드를 반환하도록 ChatForYouResponse.ofJoinRoom을 업데이트합니다.
- 프론트엔드 Kurento 서비스가 joinRoom 메시지에서 "roomId"를 보내도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable joining password-protected chat rooms by adding a join-specific response model, updating controller endpoints and WebSocket handling to use roomId, and aligning the frontend message payload.

Bug Fixes:
- Allow entry into secret chat rooms by using the new join response mapping.
- Fix WebSocket handler to read "roomId" instead of "room".
- Reset Kurento room state to CREATED on cleanup.

Enhancements:
- Introduce ChatRoomOutVo.ofJoin to include userId and nickName and exclude null JSON fields.
- Switch admin and join endpoints to use the ofJoin response DTO.
- Update ChatForYouResponse.ofJoinRoom to return the join-specific payload.
- Update frontend Kurento service to send "roomId" in joinRoom messages.

</details>