### PR TITLE
#86 electron window 버전 접속 오류

### DIFF
--- a/.github/workflows/chatforyou_release_major.yml
+++ b/.github/workflows/chatforyou_release_major.yml
@@ -1,18 +1,34 @@
 name: Release ChatForYou Desktop by major version
 
+permissions:
+  contents: write
+  pull-requests: read
+
 on:
   push:
     branches:
-      - chatforyou_v2  # 메인 브랜치 이름
+      - chatforyou_v2
+  pull_request:
+    types: [closed]
+    branches:
+      - chatforyou_v2
 
 jobs:
   bump_major_version:
     runs-on: ubuntu-latest
+    # feat 브랜치가 머지되었을 때만 실행
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/chatforyou_v2') ||
+      (github.event_name == 'pull_request' && 
+       github.event.pull_request.merged == true && 
+       startsWith(github.event.pull_request.head.ref, 'feat/'))
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # 전체 커밋과 태그 히스토리 모두 가져오기 위해 필요
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: chatforyou_v2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -42,9 +58,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # 메이저 버전 올라간 커밋과 생성된 태그를 원격 저장소에 푸시
+          # 현재 브랜치와 새로 생성된 태그를 원격 저장소에 푸시
           git push origin chatforyou_v2
-          git push origin ${{ steps.bump_version.outputs.new_version }}
+          # 새로 생성된 태그만 푸시 (npm version이 생성한 태그)
+          NEW_TAG="v$(node -p "require('./chatforyou-desktop/package.json').version")"
+          echo "Pushing new tag: $NEW_TAG"
+          git push origin "$NEW_TAG"
 
   build_and_release:
     needs: bump_major_version
@@ -76,7 +95,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: chatforyou_v2  # 최신 커밋을 가져오기 위해
+        ref: chatforyou_v2
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
       
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/chatforyou-desktop/package.json
+++ b/chatforyou-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatforyou-desktop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ChatForYou Desktop Application built with Electron",
   "main": "src/main/electron-main.js",
   "scripts": {

--- a/chatforyou-desktop/src/.build-info.json
+++ b/chatforyou-desktop/src/.build-info.json
@@ -1,6 +1,6 @@
 {
-  "syncedAt": "2025-08-03T15:50:56.714Z",
-  "sourceCommit": "482f45d6",
-  "version": "1.0.0",
+  "syncedAt": "2025-08-05T13:48:28.065Z",
+  "sourceCommit": "2fb29ee2",
+  "version": "1.0.1",
   "environment": "prod"
 }

--- a/chatforyou-desktop/src/config/config.js
+++ b/chatforyou-desktop/src/config/config.js
@@ -1,5 +1,5 @@
 // ChatForYou Electron Configuration
-// Auto-generated from web config on 2025-08-03T15:50:56.713Z
+// Auto-generated from web config on 2025-08-05T13:48:28.065Z
 
 window.__CONFIG__ = {
   "API_BASE_URL": "https://hjproject.kro.kr/chatforyou/api",
@@ -13,7 +13,7 @@ window.__CONFIG__ = {
   "APP_VERSION": "1.0.0",
   "PLATFORM_TYPE": "desktop",
   "CONVERTED_FROM": "web",
-  "CONVERSION_DATE": "2025-08-03T15:50:56.713Z"
+  "CONVERSION_DATE": "2025-08-05T13:48:28.065Z"
 };
 
 // Electron specific utilities

--- a/chatforyou-desktop/src/config/config.local.js
+++ b/chatforyou-desktop/src/config/config.local.js
@@ -1,5 +1,5 @@
 // ChatForYou Electron Configuration
-// Auto-generated from web config on 2025-08-03T15:50:56.713Z
+// Auto-generated from web config on 2025-08-05T13:48:28.064Z
 
 window.__CONFIG__ = {
   "API_BASE_URL": "http://localhost:8080/chatforyou/api",
@@ -13,7 +13,7 @@ window.__CONFIG__ = {
   "APP_VERSION": "1.0.0",
   "PLATFORM_TYPE": "desktop",
   "CONVERTED_FROM": "web",
-  "CONVERSION_DATE": "2025-08-03T15:50:56.713Z"
+  "CONVERSION_DATE": "2025-08-05T13:48:28.064Z"
 };
 
 // Electron specific utilities

--- a/chatforyou-desktop/src/config/config.prod.js
+++ b/chatforyou-desktop/src/config/config.prod.js
@@ -1,5 +1,5 @@
 // ChatForYou Electron Configuration
-// Auto-generated from web config on 2025-08-03T15:50:56.713Z
+// Auto-generated from web config on 2025-08-05T13:48:28.064Z
 
 window.__CONFIG__ = {
   "API_BASE_URL": "https://hjproject.kro.kr/chatforyou/api",
@@ -13,7 +13,7 @@ window.__CONFIG__ = {
   "APP_VERSION": "1.0.0",
   "PLATFORM_TYPE": "desktop",
   "CONVERTED_FROM": "web",
-  "CONVERSION_DATE": "2025-08-03T15:50:56.713Z"
+  "CONVERSION_DATE": "2025-08-05T13:48:28.064Z"
 };
 
 // Electron specific utilities

--- a/chatforyou-desktop/src/main/electron-main.js
+++ b/chatforyou-desktop/src/main/electron-main.js
@@ -66,7 +66,7 @@ function isValidLocalPath(fileUrl) {
             return false;
         }
         
-        // 파일 확장자 검증 (더 관대한 허용)
+        // 파일 확장자 검증
         const allowedExtensions = [
             '.html', '.htm', '.css', '.js', '.json', '.txt',
             '.svg', '.png', '.jpg', '.jpeg', '.gif', '.ico', '.webp',
@@ -620,13 +620,13 @@ app.on('web-contents-created', (event, contents) => {
     contents.setWindowOpenHandler(({ url }) => {
         if (url.startsWith('file://')) {
             // 보안: file:// URL의 경로 유효성 검사
-            // if (isValidLocalPath(url)) {
-            //     log.debug(`로컬 파일 네비게이션 허용: ${url}`);
-            //     return { action: 'allow' };
-            // } else {
-            //     log.warn(`보안: 허용되지 않은 파일 경로 차단: ${url}`);
-            //     return { action: 'deny' };
-            // }
+            if (isValidLocalPath(url)) {
+                log.debug(`로컬 파일 네비게이션 허용: ${url}`);
+                return { action: 'allow' };
+            } else {
+                log.warn(`보안: 허용되지 않은 파일 경로 차단: ${url}`);
+                return { action: 'deny' };
+            }
         }
         shell.openExternal(url);
         log.debug(`외부 링크를 기본 브라우저에서 열기: ${url}`);
@@ -635,11 +635,11 @@ app.on('web-contents-created', (event, contents) => {
     contents.on('will-navigate', (event, url) => {
         if (url.startsWith('file://')) {
             // 보안: 경로 유효성 검사
-            // if (!isValidLocalPath(url)) {
-            //     log.warn(`보안: will-navigate에서 허용되지 않은 경로 차단: ${url}`);
-            //     event.preventDefault();
-            //     return;
-            // }
+            if (!isValidLocalPath(url)) {
+                log.warn(`보안: will-navigate에서 허용되지 않은 경로 차단: ${url}`);
+                event.preventDefault();
+                return;
+            }
             
             // 로컬 파일 네비게이션 처리
             const urlPath = url.replace('file://', '');
@@ -660,10 +660,10 @@ app.on('web-contents-created', (event, contents) => {
                 const correctUrl = `file://${correctPath}${queryString}`;
                 
                 // 수정된 URL도 보안 검증
-                // if (!isValidLocalPath(correctUrl)) {
-                //     log.warn(`보안: 수정된 URL도 허용되지 않음: ${correctUrl}`);
-                //     return;
-                // }
+                if (!isValidLocalPath(correctUrl)) {
+                    log.warn(`보안: 수정된 URL도 허용되지 않음: ${correctUrl}`);
+                    return;
+                }
                 
                 log.debug(`HTML 네비게이션 수정: ${url} -> ${correctUrl}`);
                 contents.loadURL(correctUrl);

--- a/chatforyou-desktop/src/main/electron-main.js
+++ b/chatforyou-desktop/src/main/electron-main.js
@@ -13,50 +13,71 @@ let mainWindow;
 let updateManager = null; // AutoUpdateManager 인스턴스
 
 /**
- * 보안: file:// URL의 경로가 허용되는 디렉터리인지 검증
+ * 보안: file:// URL의 경로가 허용되는 디렉토리인지 검증
  * Directory Traversal 공격 방지
  */
 function isValidLocalPath(fileUrl) {
     try {
-        // file:// 프로토콜 제거
-        const urlPath = fileUrl.replace('file://', '');
+        // file:// 프로토콜 제거 및 Windows 경로 형식 처리
+        let urlPath = fileUrl.replace('file://', '');
+        
+        // Windows에서 슬래시 3개 (//) 처리
+        if (process.platform === 'win32' && urlPath.startsWith('/')) {
+            urlPath = urlPath.substring(1);
+        }
         
         // URL 디코딩 (..%2F 등의 인코딩된 경로 탐색 시도 방지)
         const decodedPath = decodeURIComponent(urlPath);
         
-        // 정규화된 절대 경로로 변환
-        const normalizedPath = path.resolve(decodedPath.split('?')[0]); // 쿼리 파라미터 제거
+        // 쿼리 파라미터와 해시 제거
+        const cleanPath = decodedPath.split('?')[0].split('#')[0];
         
-        // 허용되는 디렉터리 목록 (앱 디렉터리 내부만 허용)
+        // 정규화된 절대 경로로 변환 - Windows/Unix 호환
+        const normalizedPath = path.resolve(cleanPath);
+        
+        // 허용되는 디렉토리 목록 (앱 디렉토리 내부만 허용)
         const appDir = path.resolve(__dirname, '..');
         const allowedDirs = [
             path.join(appDir, 'templates'),
             path.join(appDir, 'static'),
-            path.join(appDir, 'config')
+            path.join(appDir, 'config'),
+            path.join(appDir, 'assets'),
+            path.join(appDir, 'resources')
         ];
         
-        // 경로가 허용된 디렉터리 내부에 있는지 확인
+        // 경로가 허용된 디렉터리 내부에 있는지 확인 - Windows 대소문자 무시
         const isInAllowedDir = allowedDirs.some(allowedDir => {
-            return normalizedPath.startsWith(path.resolve(allowedDir));
+            const resolvedAllowedDir = path.resolve(allowedDir);
+            if (process.platform === 'win32') {
+                return normalizedPath.toLowerCase().startsWith(resolvedAllowedDir.toLowerCase());
+            }
+            return normalizedPath.startsWith(resolvedAllowedDir);
         });
         
         if (!isInAllowedDir) {
-            log.warn(`보안: 허용되지 않은 디렉터리 접근 시도: ${normalizedPath}`);
+            log.warn(`보안: 허용되지 않은 디렉토리 접근 시도: ${normalizedPath}`);
             return false;
         }
         
-        // .. 경로 탐색 시도 차단 (정규화 후에도 추가 검사)
-        if (normalizedPath.includes('..') || decodedPath.includes('..')) {
-            log.warn(`보안: 경로 탐색 시도 차단: ${decodedPath}`);
+        // Directory traversal 공격 차단 - 더 정확한 검사
+        const relativePath = path.relative(appDir, normalizedPath);
+        if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+            log.warn(`보안: 경로 탐색 시도 차단: ${relativePath}`);
             return false;
         }
         
-        // 파일 확장자 검증 (허용되는 파일만)
-        const allowedExtensions = ['.html', '.css', '.js', '.json', '.svg', '.png', '.jpg', '.jpeg', '.gif', '.ico'];
+        // 파일 확장자 검증 (더 관대한 허용)
+        const allowedExtensions = [
+            '.html', '.htm', '.css', '.js', '.json', '.txt',
+            '.svg', '.png', '.jpg', '.jpeg', '.gif', '.ico', '.webp',
+            '.woff', '.woff2', '.ttf', '.eot' // 웹폰트 지원
+        ];
+        
         const fileExtension = path.extname(normalizedPath).toLowerCase();
         
-        if (!allowedExtensions.includes(fileExtension)) {
-            log.warn(`보안: 허용되지 않은 파일 확장자: ${fileExtension}`);
+        // 확장자가 없는 경우나 허용된 확장자인 경우만 통과
+        if (fileExtension && !allowedExtensions.includes(fileExtension)) {
+            log.warn(`보안: 허용되지 않은 파일 확장자: ${fileExtension} (${normalizedPath})`);
             return false;
         }
         
@@ -599,13 +620,13 @@ app.on('web-contents-created', (event, contents) => {
     contents.setWindowOpenHandler(({ url }) => {
         if (url.startsWith('file://')) {
             // 보안: file:// URL의 경로 유효성 검사
-            if (isValidLocalPath(url)) {
-                log.debug(`로컬 파일 네비게이션 허용: ${url}`);
-                return { action: 'allow' };
-            } else {
-                log.warn(`보안: 허용되지 않은 파일 경로 차단: ${url}`);
-                return { action: 'deny' };
-            }
+            // if (isValidLocalPath(url)) {
+            //     log.debug(`로컬 파일 네비게이션 허용: ${url}`);
+            //     return { action: 'allow' };
+            // } else {
+            //     log.warn(`보안: 허용되지 않은 파일 경로 차단: ${url}`);
+            //     return { action: 'deny' };
+            // }
         }
         shell.openExternal(url);
         log.debug(`외부 링크를 기본 브라우저에서 열기: ${url}`);
@@ -614,11 +635,11 @@ app.on('web-contents-created', (event, contents) => {
     contents.on('will-navigate', (event, url) => {
         if (url.startsWith('file://')) {
             // 보안: 경로 유효성 검사
-            if (!isValidLocalPath(url)) {
-                log.warn(`보안: will-navigate에서 허용되지 않은 경로 차단: ${url}`);
-                event.preventDefault();
-                return;
-            }
+            // if (!isValidLocalPath(url)) {
+            //     log.warn(`보안: will-navigate에서 허용되지 않은 경로 차단: ${url}`);
+            //     event.preventDefault();
+            //     return;
+            // }
             
             // 로컬 파일 네비게이션 처리
             const urlPath = url.replace('file://', '');
@@ -639,10 +660,10 @@ app.on('web-contents-created', (event, contents) => {
                 const correctUrl = `file://${correctPath}${queryString}`;
                 
                 // 수정된 URL도 보안 검증
-                if (!isValidLocalPath(correctUrl)) {
-                    log.warn(`보안: 수정된 URL도 허용되지 않음: ${correctUrl}`);
-                    return;
-                }
+                // if (!isValidLocalPath(correctUrl)) {
+                //     log.warn(`보안: 수정된 URL도 허용되지 않음: ${correctUrl}`);
+                //     return;
+                // }
                 
                 log.debug(`HTML 네비게이션 수정: ${url} -> ${correctUrl}`);
                 contents.loadURL(correctUrl);


### PR DESCRIPTION
isValidLocalPath 에서 file:// URL 보안 처리 중 특정 디렉토리 누락으로 인한 실행 에러
- 누락된 디렉토리 추가
- eat 브렌치에서 chatforyou_v2 브렌치로 업데이트 되었을 경우에만 메이저 버전 업데이트되도록 workflow 수정

## Sourcery 요약

file:// URL 유효성 검사를 강화하고, 주요 버전 릴리스 워크플로우를 개선하며, 데스크톱 앱 버전을 1.0.1로 업데이트합니다.

버그 수정:
- 누락된 'assets' 및 'resources' 디렉터리를 isValidLocalPath 허용 목록에 추가하여 file:// 접근 오류 수정

개선 사항:
- Windows 경로를 처리하고, 쿼리/해시를 제거하며, 디렉터리 트래버설 검사를 적용하고, 추가 파일 확장자를 지원하도록 file:// URL 유효성 검사 개선

CI:
- chatforyou_v2로 'feat/' 브랜치가 병합될 때만 주 버전(major version)을 올리고 새 태그만 푸시하도록 릴리스 워크플로우 업데이트

기타 작업:
- 데스크톱 앱 버전을 1.0.1로 업데이트하고 자동 생성된 구성 변환 타임스탬프 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden file:// URL validation, refine major version release workflow, and bump desktop app version to 1.0.1.

Bug Fixes:
- Add missing 'assets' and 'resources' directories to isValidLocalPath allowed list to fix file:// access errors

Enhancements:
- Refine file:// URL validation to handle Windows paths, strip query/hash, enforce directory traversal checks, and support additional file extensions

CI:
- Update release workflow to only bump major version on merges of 'feat/' branches into chatforyou_v2 and push only the new tag

Chores:
- Bump desktop app version to 1.0.1 and update auto-generated config conversion timestamps

</details>