### PR TITLE
#87 bug :: 자동 업데이트 시 '나중에' 버튼 외 닫기 버튼으로 업데이트 무시 가능한 현상

### DIFF
--- a/.github/workflows/chatforyou_release_major.yml
+++ b/.github/workflows/chatforyou_release_major.yml
@@ -1,307 +1,307 @@
-name: Release ChatForYou Desktop by major version
+# name: Release ChatForYou Desktop by major version
 
-permissions:
-  contents: write
-  pull-requests: read
+# permissions:
+#   contents: write
+#   pull-requests: read
 
-on:
-  push:
-    branches:
-      - chatforyou_v2
-  pull_request:
-    types: [closed]
-    branches:
-      - chatforyou_v2
+# on:
+#   push:
+#     branches:
+#       - chatforyou_v2
+#   pull_request:
+#     types: [closed]
+#     branches:
+#       - chatforyou_v2
 
-jobs:
-  bump_major_version:
-    runs-on: ubuntu-latest
-    # feat 브랜치가 머지되었을 때만 실행
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/chatforyou_v2') ||
-      (github.event_name == 'pull_request' && 
-       github.event.pull_request.merged == true && 
-       startsWith(github.event.pull_request.head.ref, 'feat/'))
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # 전체 커밋과 태그 히스토리 모두 가져오기 위해 필요
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: chatforyou_v2
+# jobs:
+#   bump_major_version:
+#     runs-on: ubuntu-latest
+#     # feat 브랜치가 머지되었을 때만 실행
+#     if: |
+#       (github.event_name == 'push' && github.ref == 'refs/heads/chatforyou_v2') ||
+#       (github.event_name == 'pull_request' && 
+#        github.event.pull_request.merged == true && 
+#        startsWith(github.event.pull_request.head.ref, 'feat/'))
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 0  # 전체 커밋과 태그 히스토리 모두 가져오기 위해 필요
+#           token: ${{ secrets.GITHUB_TOKEN }}
+#           ref: chatforyou_v2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
+#       - name: Setup Node.js
+#         uses: actions/setup-node@v4
+#         with:
+#           node-version: 18
 
-      - name: Configure Git User
-        run: |
-          git config user.name "ChatForYou Release Bot"
-          git config user.email "sejon@gmail.com"
+#       - name: Configure Git User
+#         run: |
+#           git config user.name "ChatForYou Release Bot"
+#           git config user.email "sejon@gmail.com"
 
-      - name: Install dependencies
-        run: |
-          cd chatforyou-desktop
-          npm ci
+#       - name: Install dependencies
+#         run: |
+#           cd chatforyou-desktop
+#           npm ci
 
-      - name: Bump major version
-        id: bump_version
-        run: |
-          cd chatforyou-desktop
-          # package.json의 메이저 버전을 1 상승시키고, git 커밋과 태그 자동 생성
-          npm version major -m "ChatForYou Electron App Released %s"
-          NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "new_version=v${NEW_VERSION}" >> $GITHUB_OUTPUT
+#       - name: Bump major version
+#         id: bump_version
+#         run: |
+#           cd chatforyou-desktop
+#           # package.json의 메이저 버전을 1 상승시키고, git 커밋과 태그 자동 생성
+#           npm version major -m "ChatForYou Electron App Released %s"
+#           NEW_VERSION=$(node -p "require('./package.json').version")
+#           echo "new_version=v${NEW_VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Push commit and tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # 현재 브랜치와 새로 생성된 태그를 원격 저장소에 푸시
-          git push origin chatforyou_v2
-          # 새로 생성된 태그만 푸시 (npm version이 생성한 태그)
-          NEW_TAG="v$(node -p "require('./chatforyou-desktop/package.json').version")"
-          echo "Pushing new tag: $NEW_TAG"
-          git push origin "$NEW_TAG"
+#       - name: Push commit and tag
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         run: |
+#           # 현재 브랜치와 새로 생성된 태그를 원격 저장소에 푸시
+#           git push origin chatforyou_v2
+#           # 새로 생성된 태그만 푸시 (npm version이 생성한 태그)
+#           NEW_TAG="v$(node -p "require('./chatforyou-desktop/package.json').version")"
+#           echo "Pushing new tag: $NEW_TAG"
+#           git push origin "$NEW_TAG"
 
-  build_and_release:
-    needs: bump_major_version
-    runs-on: ${{ matrix.os }}
+#   build_and_release:
+#     needs: bump_major_version
+#     runs-on: ${{ matrix.os }}
     
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            platform: mac
-            build-script: build:mac
-            artifact-name: macos-build
-            artifact-pattern: |
-              chatforyou-desktop/dist/*.dmg
-              chatforyou-desktop/dist/*.dmg.blockmap
-              chatforyou-desktop/dist/*.zip
-              chatforyou-desktop/dist/*.zip.blockmap
-              chatforyou-desktop/dist/latest-mac.yml
-          - os: windows-latest
-            platform: win
-            build-script: build:win
-            artifact-name: windows-build
-            artifact-pattern: |
-              chatforyou-desktop/dist/*.exe
-              chatforyou-desktop/dist/*.exe.blockmap
-              chatforyou-desktop/dist/latest.yml
+#     strategy:
+#       matrix:
+#         include:
+#           - os: macos-latest
+#             platform: mac
+#             build-script: build:mac
+#             artifact-name: macos-build
+#             artifact-pattern: |
+#               chatforyou-desktop/dist/*.dmg
+#               chatforyou-desktop/dist/*.dmg.blockmap
+#               chatforyou-desktop/dist/*.zip
+#               chatforyou-desktop/dist/*.zip.blockmap
+#               chatforyou-desktop/dist/latest-mac.yml
+#           - os: windows-latest
+#             platform: win
+#             build-script: build:win
+#             artifact-name: windows-build
+#             artifact-pattern: |
+#               chatforyou-desktop/dist/*.exe
+#               chatforyou-desktop/dist/*.exe.blockmap
+#               chatforyou-desktop/dist/latest.yml
         
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: chatforyou_v2
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+#     steps:
+#     - name: Checkout code
+#       uses: actions/checkout@v4
+#       with:
+#         ref: chatforyou_v2
+#         fetch-depth: 0
+#         token: ${{ secrets.GITHUB_TOKEN }}
       
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-        cache: 'npm'
-        cache-dependency-path: chatforyou-desktop/package-lock.json
+#     - name: Setup Node.js
+#       uses: actions/setup-node@v4
+#       with:
+#         node-version: '18'
+#         cache: 'npm'
+#         cache-dependency-path: chatforyou-desktop/package-lock.json
         
-    - name: Install dependencies
-      run: |
-        cd chatforyou-desktop
-        npm ci
+#     - name: Install dependencies
+#       run: |
+#         cd chatforyou-desktop
+#         npm ci
         
-    - name: Build Electron app (통합 빌드 시스템)
-      run: |
-        cd chatforyou-desktop
-        npm run ${{ matrix.build-script }}
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CSC_IDENTITY_AUTO_DISCOVERY: false
+#     - name: Build Electron app (통합 빌드 시스템)
+#       run: |
+#         cd chatforyou-desktop
+#         npm run ${{ matrix.build-script }}
+#       env:
+#         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         CSC_IDENTITY_AUTO_DISCOVERY: false
         
-    ## 보안 설정 이슈로 인한 mac 자동 업데이트(zip 파일 빌드) 임시 비활성화 -> 추후 해결 시 활성화 예정     
-    # - name: Sign macOS ZIP contents (for macOS)
-    #   if: matrix.platform == 'mac'
-    #   run: |
-    #     cd chatforyou-desktop
-    #     # Find and sign all .app bundles in ZIP files
-    #     for zipfile in dist/*.zip; do
-    #       if [ -f "$zipfile" ]; then
-    #         echo "Processing ZIP file: $zipfile"
-    #         # Create temp directory
-    #         temp_dir=$(mktemp -d)
-    #         # Extract ZIP
-    #         unzip -q "$zipfile" -d "$temp_dir"
-    #         # Find .app bundles and sign them
-    #         find "$temp_dir" -name "*.app" -type d | while read -r app_path; do
-    #           echo "Signing app: $app_path"
-    #           codesign --force --deep --sign - "$app_path"
-    #           codesign --verify --verbose "$app_path"
-    #         done
-    #         # Re-create ZIP with signed apps
-    #         cd "$temp_dir"
-    #         zip -r -q "../$(basename "$zipfile")" .
-    #         cd - > /dev/null
-    #         mv "$temp_dir/../$(basename "$zipfile")" "$zipfile"
-    #         # Cleanup
-    #         rm -rf "$temp_dir"
-    #         echo "Re-signed ZIP: $zipfile"
+#     ## 보안 설정 이슈로 인한 mac 자동 업데이트(zip 파일 빌드) 임시 비활성화 -> 추후 해결 시 활성화 예정     
+#     # - name: Sign macOS ZIP contents (for macOS)
+#     #   if: matrix.platform == 'mac'
+#     #   run: |
+#     #     cd chatforyou-desktop
+#     #     # Find and sign all .app bundles in ZIP files
+#     #     for zipfile in dist/*.zip; do
+#     #       if [ -f "$zipfile" ]; then
+#     #         echo "Processing ZIP file: $zipfile"
+#     #         # Create temp directory
+#     #         temp_dir=$(mktemp -d)
+#     #         # Extract ZIP
+#     #         unzip -q "$zipfile" -d "$temp_dir"
+#     #         # Find .app bundles and sign them
+#     #         find "$temp_dir" -name "*.app" -type d | while read -r app_path; do
+#     #           echo "Signing app: $app_path"
+#     #           codesign --force --deep --sign - "$app_path"
+#     #           codesign --verify --verbose "$app_path"
+#     #         done
+#     #         # Re-create ZIP with signed apps
+#     #         cd "$temp_dir"
+#     #         zip -r -q "../$(basename "$zipfile")" .
+#     #         cd - > /dev/null
+#     #         mv "$temp_dir/../$(basename "$zipfile")" "$zipfile"
+#     #         # Cleanup
+#     #         rm -rf "$temp_dir"
+#     #         echo "Re-signed ZIP: $zipfile"
             
-    #         echo "Re-signed ZIP: $zipfile"
-    #       fi
-    #     done
+#     #         echo "Re-signed ZIP: $zipfile"
+#     #       fi
+#     #     done
 
-    # - name: Update SHA512 checksums using sha512-builder.js
-    #   working-directory: ./chatforyou-desktop
-    #   if: matrix.platform == 'mac'
-    #   run: |
-    #     echo "🔧 SHA512 체크섬 자동 업데이트 시작..."
-    #     node build-scripts/sha512-builder.js
-    #     echo "✅ SHA512 체크섬 업데이트 완료"
+#     # - name: Update SHA512 checksums using sha512-builder.js
+#     #   working-directory: ./chatforyou-desktop
+#     #   if: matrix.platform == 'mac'
+#     #   run: |
+#     #     echo "🔧 SHA512 체크섬 자동 업데이트 시작..."
+#     #     node build-scripts/sha512-builder.js
+#     #     echo "✅ SHA512 체크섬 업데이트 완료"
         
-    #     echo "📋 업데이트된 latest-mac.yml 내용:"
-    #     cat dist/latest-mac.yml
+#     #     echo "📋 업데이트된 latest-mac.yml 내용:"
+#     #     cat dist/latest-mac.yml
         
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ matrix.artifact-name }}
-        path: ${{ matrix.artifact-pattern }}
-        retention-days: 7
+#     - name: Upload artifacts
+#       uses: actions/upload-artifact@v4
+#       with:
+#         name: ${{ matrix.artifact-name }}
+#         path: ${{ matrix.artifact-pattern }}
+#         retention-days: 7
 
-  create_release:
-    needs: [bump_major_version, build_and_release]
-    runs-on: ubuntu-latest
+#   create_release:
+#     needs: [bump_major_version, build_and_release]
+#     runs-on: ubuntu-latest
     
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: chatforyou_v2
-        fetch-depth: 0  # 태그 히스토리를 가져오기 위해
+#     steps:
+#     - name: Checkout code
+#       uses: actions/checkout@v4
+#       with:
+#         ref: chatforyou_v2
+#         fetch-depth: 0  # 태그 히스토리를 가져오기 위해
       
-    - name: Download all artifacts
-      uses: actions/download-artifact@v4
+#     - name: Download all artifacts
+#       uses: actions/download-artifact@v4
       
-    - name: Get version from package.json
-      id: get_version
-      run: |
-        cd chatforyou-desktop
-        VERSION="v$(node -p "require('./package.json').version")"
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "version_number=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+#     - name: Get version from package.json
+#       id: get_version
+#       run: |
+#         cd chatforyou-desktop
+#         VERSION="v$(node -p "require('./package.json').version")"
+#         echo "version=${VERSION}" >> $GITHUB_OUTPUT
+#         echo "version_number=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       
-    - name: Generate Release Notes
-      id: release_notes
-      run: |
-        # 이전 태그와 현재 태그 사이의 커밋들로부터 릴리즈 노트 생성
-        CURRENT_TAG="${{ steps.get_version.outputs.version }}"
-        PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -v "$CURRENT_TAG" | head -n 1)
+#     - name: Generate Release Notes
+#       id: release_notes
+#       run: |
+#         # 이전 태그와 현재 태그 사이의 커밋들로부터 릴리즈 노트 생성
+#         CURRENT_TAG="${{ steps.get_version.outputs.version }}"
+#         PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -v "$CURRENT_TAG" | head -n 1)
         
-        echo "Current tag: $CURRENT_TAG"
-        echo "Previous tag: $PREVIOUS_TAG"
+#         echo "Current tag: $CURRENT_TAG"
+#         echo "Previous tag: $PREVIOUS_TAG"
         
-        if [ -z "$PREVIOUS_TAG" ]; then
-          echo "No previous tag found, using recent commits"
-          COMMITS=$(git log --pretty=format:"- %s (%h)" --reverse -10)
-        else
-          echo "Getting commits between $PREVIOUS_TAG and HEAD"
-          COMMITS=$(git log --pretty=format:"- %s (%h)" --reverse "$PREVIOUS_TAG..HEAD")
-        fi
+#         if [ -z "$PREVIOUS_TAG" ]; then
+#           echo "No previous tag found, using recent commits"
+#           COMMITS=$(git log --pretty=format:"- %s (%h)" --reverse -10)
+#         else
+#           echo "Getting commits between $PREVIOUS_TAG and HEAD"
+#           COMMITS=$(git log --pretty=format:"- %s (%h)" --reverse "$PREVIOUS_TAG..HEAD")
+#         fi
         
-        # 릴리즈 노트 생성
-        cat > release_notes.md << 'EOF'
-        ## 🎉 ChatForYou ${{ steps.get_version.outputs.version }} 메이저 릴리스
+#         # 릴리즈 노트 생성
+#         cat > release_notes.md << 'EOF'
+#         ## 🎉 ChatForYou ${{ steps.get_version.outputs.version }} 메이저 릴리스
         
-        ### 📝 변경사항
+#         ### 📝 변경사항
         
-        EOF
+#         EOF
         
-        if [ -n "$COMMITS" ]; then
-          echo "$COMMITS" >> release_notes.md
-        else
-          echo "- 메이저 버전 업데이트 및 기능 개선" >> release_notes.md
-        fi
+#         if [ -n "$COMMITS" ]; then
+#           echo "$COMMITS" >> release_notes.md
+#         else
+#           echo "- 메이저 버전 업데이트 및 기능 개선" >> release_notes.md
+#         fi
         
-        cat >> release_notes.md << 'EOF'
+#         cat >> release_notes.md << 'EOF'
         
-        ## 📥 다운로드
+#         ## 📥 다운로드
         
-        | 플랫폼 | 파일 | 설명 |
-        |--------|------|------|
-        | macOS (Apple Silicon) | ChatForYou-${{ steps.get_version.outputs.version_number }}-arm64.dmg | Apple M1/M2 Mac용 |
-        | macOS (Intel) | ChatForYou-${{ steps.get_version.outputs.version_number }}.dmg | Intel Mac용 |
-        | Windows | ChatForYou-Setup-${{ steps.get_version.outputs.version_number }}.exe | Windows 10/11 64-bit |
+#         | 플랫폼 | 파일 | 설명 |
+#         |--------|------|------|
+#         | macOS (Apple Silicon) | ChatForYou-${{ steps.get_version.outputs.version_number }}-arm64.dmg | Apple M1/M2 Mac용 |
+#         | macOS (Intel) | ChatForYou-${{ steps.get_version.outputs.version_number }}.dmg | Intel Mac용 |
+#         | Windows | ChatForYou-Setup-${{ steps.get_version.outputs.version_number }}.exe | Windows 10/11 64-bit |
         
-        ## 🚀 설치 방법
+#         ## 🚀 설치 방법
         
-        ### macOS
-        1. 해당하는 DMG 파일을 다운로드합니다
-        2. DMG 파일을 열고 ChatForYou 아이콘을 Applications 폴더로 드래그합니다
-        3. Launchpad 또는 Applications 폴더에서 ChatForYou를 실행합니다
+#         ### macOS
+#         1. 해당하는 DMG 파일을 다운로드합니다
+#         2. DMG 파일을 열고 ChatForYou 아이콘을 Applications 폴더로 드래그합니다
+#         3. Launchpad 또는 Applications 폴더에서 ChatForYou를 실행합니다
         
-        ⚠️ **macOS "손상된 파일" 에러 해결 방법**
+#         ⚠️ **macOS "손상된 파일" 에러 해결 방법**
         
-        macOS에서 "손상된 파일"이라는 에러가 발생할 경우:
+#         macOS에서 "손상된 파일"이라는 에러가 발생할 경우:
         
-        **방법 1: 우클릭으로 열기**
-        1. ChatForYou 앱을 우클릭 → "열기" 선택
-        2. 경고 대화상자에서 "열기" 클릭
+#         **방법 1: 우클릭으로 열기**
+#         1. ChatForYou 앱을 우클릭 → "열기" 선택
+#         2. 경고 대화상자에서 "열기" 클릭
         
-        **방법 2: 터미널 명령어 (권장)**
-        ```bash
-        # 다운로드한 DMG 파일의 quarantine 속성 제거
-        xattr -r -d com.apple.quarantine ~/Downloads/ChatForYou-*.dmg
+#         **방법 2: 터미널 명령어 (권장)**
+#         ```bash
+#         # 다운로드한 DMG 파일의 quarantine 속성 제거
+#         xattr -r -d com.apple.quarantine ~/Downloads/ChatForYou-*.dmg
         
-        # 또는 설치된 앱의 quarantine 속성 제거
-        xattr -r -d com.apple.quarantine /Applications/ChatForYou.app
-        ```
+#         # 또는 설치된 앱의 quarantine 속성 제거
+#         xattr -r -d com.apple.quarantine /Applications/ChatForYou.app
+#         ```
         
-        **왜 이런 에러가 발생하나요?**
-        - macOS Gatekeeper는 Apple 개발자 인증서로 서명되지 않은 앱을 자동으로 차단합니다
-        - ChatForYou는 개인 프로젝트로 Apple Developer Program에 등록되지 않았습니다
-        - 이는 macOS만의 보안 정책으로, Windows에서는 발생하지 않는 문제입니다
+#         **왜 이런 에러가 발생하나요?**
+#         - macOS Gatekeeper는 Apple 개발자 인증서로 서명되지 않은 앱을 자동으로 차단합니다
+#         - ChatForYou는 개인 프로젝트로 Apple Developer Program에 등록되지 않았습니다
+#         - 이는 macOS만의 보안 정책으로, Windows에서는 발생하지 않는 문제입니다
         
-        ### Windows
-        1. Setup.exe 파일을 다운로드합니다
-        2. 파일을 실행하고 설치 마법사를 따라 진행합니다
-        3. 바탕화면 또는 시작 메뉴에서 ChatForYou를 실행합니다
+#         ### Windows
+#         1. Setup.exe 파일을 다운로드합니다
+#         2. 파일을 실행하고 설치 마법사를 따라 진행합니다
+#         3. 바탕화면 또는 시작 메뉴에서 ChatForYou를 실행합니다
         
-        ## 🔄 자동 업데이트
+#         ## 🔄 자동 업데이트
         
-        앱이 백그라운드에서 자동으로 새 버전을 확인하고, 업데이트가 있을 때 알림을 표시합니다.
+#         앱이 백그라운드에서 자동으로 새 버전을 확인하고, 업데이트가 있을 때 알림을 표시합니다.
         
-        ## 📞 지원
+#         ## 📞 지원
         
-        문제가 발생하거나 기능 요청이 있으시면 [GitHub Issues](https://github.com/SeJonJ/ChatForYou/issues)에 알려주세요!
+#         문제가 발생하거나 기능 요청이 있으시면 [GitHub Issues](https://github.com/SeJonJ/ChatForYou/issues)에 알려주세요!
         
-        EOF
+#         EOF
         
-        # multiline output을 위한 EOF delimiter 설정
-        {
-          echo 'release_body<<EOF'
-          cat release_notes.md
-          echo 'EOF'
-        } >> $GITHUB_OUTPUT
+#         # multiline output을 위한 EOF delimiter 설정
+#         {
+#           echo 'release_body<<EOF'
+#           cat release_notes.md
+#           echo 'EOF'
+#         } >> $GITHUB_OUTPUT
         
-    - name: Create Release
-      id: create_release
-      uses: softprops/action-gh-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.get_version.outputs.version }}
-        name: ChatForYou ${{ steps.get_version.outputs.version }} (Major Release)
-        body: ${{ steps.release_notes.outputs.release_body }}
-        draft: false
-        prerelease: false
-        files: |
-          macos-build/*.dmg
-          macos-build/*.dmg.blockmap
-          macos-build/*.zip
-          macos-build/*.zip.blockmap
-          macos-build/latest-mac.yml
-          windows-build/*.exe
-          windows-build/*.exe.blockmap
-          windows-build/latest.yml
-        fail_on_unmatched_files: false
+#     - name: Create Release
+#       id: create_release
+#       uses: softprops/action-gh-release@v1
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#       with:
+#         tag_name: ${{ steps.get_version.outputs.version }}
+#         name: ChatForYou ${{ steps.get_version.outputs.version }} (Major Release)
+#         body: ${{ steps.release_notes.outputs.release_body }}
+#         draft: false
+#         prerelease: false
+#         files: |
+#           macos-build/*.dmg
+#           macos-build/*.dmg.blockmap
+#           macos-build/*.zip
+#           macos-build/*.zip.blockmap
+#           macos-build/latest-mac.yml
+#           windows-build/*.exe
+#           windows-build/*.exe.blockmap
+#           windows-build/latest.yml
+#         fail_on_unmatched_files: false

--- a/chatforyou-desktop/auto-update/auto-updater.js
+++ b/chatforyou-desktop/auto-update/auto-updater.js
@@ -143,7 +143,10 @@ class AutoUpdateManager {
       resizable: false,
       modal: true,
       parent: this.mainWindow,
-      titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default'
+      titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+      closable: false,        // X 버튼 비활성화
+      minimizable: false,     // 최소화 방지
+      maximizable: false      // 최대화 방지
     });
 
     const updateUrl = `file://${path.join(__dirname, 'update_popup.html')}?version=${updateVersion}`;
@@ -176,6 +179,13 @@ class AutoUpdateManager {
     if (this.updateWindow) {
       this.updateWindow.close();
       this.updateWindow = null;
+    }
+    
+    // 강제 업데이트: 업데이트 창을 닫으면 앱 종료
+    if (this.updateInfo && typeof this.updateInfo === 'object') {
+      this.logger.info('강제 업데이트: 사용자가 업데이트를 거부하여 앱 종료');
+      const { app } = require('electron');
+      app.quit();
     }
   }
 

--- a/chatforyou-desktop/auto-update/auto-updater.js
+++ b/chatforyou-desktop/auto-update/auto-updater.js
@@ -146,7 +146,8 @@ class AutoUpdateManager {
       titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
       closable: false,        // X 버튼 비활성화
       minimizable: false,     // 최소화 방지
-      maximizable: false      // 최대화 방지
+      maximizable: false,      // 최대화 방지,
+      autoHideMenuBar: true,   // 메뉴바 자동 숨기기
     });
 
     const updateUrl = `file://${path.join(__dirname, 'update_popup.html')}?version=${updateVersion}`;

--- a/chatforyou-desktop/auto-update/update_popup.html
+++ b/chatforyou-desktop/auto-update/update_popup.html
@@ -375,7 +375,7 @@
                 <span>지금 다운로드</span>
             </button>
             <button class="btn btn-secondary" id="laterBtn">
-                나중에
+                나중에 업데이트(앱 종료)
             </button>
         </div>
     </div>

--- a/chatforyou-desktop/package.json
+++ b/chatforyou-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatforyou-desktop",
-  "version": "1.0.1",
+  "version": "0.0.2",
   "description": "ChatForYou Desktop Application built with Electron",
   "main": "src/main/electron-main.js",
   "scripts": {

--- a/chatforyou-desktop/package.json
+++ b/chatforyou-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatforyou-desktop",
-  "version": "0.0.2",
+  "version": "1.0.2",
   "description": "ChatForYou Desktop Application built with Electron",
   "main": "src/main/electron-main.js",
   "scripts": {

--- a/chatforyou-desktop/src/.build-info.json
+++ b/chatforyou-desktop/src/.build-info.json
@@ -1,6 +1,6 @@
 {
-  "syncedAt": "2025-08-08T12:05:06.311Z",
-  "sourceCommit": "8bb60eae",
-  "version": "0.0.2",
+  "syncedAt": "2025-08-09T13:42:11.661Z",
+  "sourceCommit": "cb7af521",
+  "version": "1.0.2",
   "environment": "prod"
 }

--- a/chatforyou-desktop/src/.build-info.json
+++ b/chatforyou-desktop/src/.build-info.json
@@ -1,6 +1,6 @@
 {
-  "syncedAt": "2025-08-05T13:48:28.065Z",
-  "sourceCommit": "2fb29ee2",
-  "version": "1.0.1",
+  "syncedAt": "2025-08-08T12:05:06.311Z",
+  "sourceCommit": "8bb60eae",
+  "version": "0.0.2",
   "environment": "prod"
 }

--- a/chatforyou-desktop/src/config/config.js
+++ b/chatforyou-desktop/src/config/config.js
@@ -1,5 +1,5 @@
 // ChatForYou Electron Configuration
-// Auto-generated from web config on 2025-08-08T12:05:06.311Z
+// Auto-generated from web config on 2025-08-09T13:42:11.661Z
 
 window.__CONFIG__ = {
   "API_BASE_URL": "https://hjproject.kro.kr/chatforyou/api",
@@ -10,10 +10,10 @@ window.__CONFIG__ = {
   "AUTO_UPDATER": true,
   "WEB_BASE_URL": "https://hjproject.kro.kr/chatforyou",
   "ELECTRON_VERSION": "unknown",
-  "APP_VERSION": "1.0.0",
+  "APP_VERSION": "1.0.2",
   "PLATFORM_TYPE": "desktop",
   "CONVERTED_FROM": "web",
-  "CONVERSION_DATE": "2025-08-08T12:05:06.311Z"
+  "CONVERSION_DATE": "2025-08-09T13:42:11.661Z"
 };
 
 // Electron specific utilities

--- a/chatforyou-desktop/src/config/config.js
+++ b/chatforyou-desktop/src/config/config.js
@@ -1,5 +1,5 @@
 // ChatForYou Electron Configuration
-// Auto-generated from web config on 2025-08-05T13:48:28.065Z
+// Auto-generated from web config on 2025-08-08T12:05:06.311Z
 
 window.__CONFIG__ = {
   "API_BASE_URL": "https://hjproject.kro.kr/chatforyou/api",
@@ -13,7 +13,7 @@ window.__CONFIG__ = {
   "APP_VERSION": "1.0.0",
   "PLATFORM_TYPE": "desktop",
   "CONVERTED_FROM": "web",
-  "CONVERSION_DATE": "2025-08-05T13:48:28.065Z"
+  "CONVERSION_DATE": "2025-08-08T12:05:06.311Z"
 };
 
 // Electron specific utilities

--- a/chatforyou-desktop/src/config/config.local.js
+++ b/chatforyou-desktop/src/config/config.local.js
@@ -1,5 +1,5 @@
 // ChatForYou Electron Configuration
-// Auto-generated from web config on 2025-08-05T13:48:28.064Z
+// Auto-generated from web config on 2025-08-08T12:05:06.310Z
 
 window.__CONFIG__ = {
   "API_BASE_URL": "http://localhost:8080/chatforyou/api",
@@ -13,7 +13,7 @@ window.__CONFIG__ = {
   "APP_VERSION": "1.0.0",
   "PLATFORM_TYPE": "desktop",
   "CONVERTED_FROM": "web",
-  "CONVERSION_DATE": "2025-08-05T13:48:28.064Z"
+  "CONVERSION_DATE": "2025-08-08T12:05:06.310Z"
 };
 
 // Electron specific utilities

--- a/chatforyou-desktop/src/config/config.local.js
+++ b/chatforyou-desktop/src/config/config.local.js
@@ -1,5 +1,5 @@
 // ChatForYou Electron Configuration
-// Auto-generated from web config on 2025-08-08T12:05:06.310Z
+// Auto-generated from web config on 2025-08-09T13:42:11.661Z
 
 window.__CONFIG__ = {
   "API_BASE_URL": "http://localhost:8080/chatforyou/api",
@@ -10,10 +10,10 @@ window.__CONFIG__ = {
   "AUTO_UPDATER": false,
   "WEB_BASE_URL": "http://localhost:3000/chatforyou",
   "ELECTRON_VERSION": "unknown",
-  "APP_VERSION": "1.0.0",
+  "APP_VERSION": "1.0.2",
   "PLATFORM_TYPE": "desktop",
   "CONVERTED_FROM": "web",
-  "CONVERSION_DATE": "2025-08-08T12:05:06.310Z"
+  "CONVERSION_DATE": "2025-08-09T13:42:11.661Z"
 };
 
 // Electron specific utilities

--- a/chatforyou-desktop/src/config/config.prod.js
+++ b/chatforyou-desktop/src/config/config.prod.js
@@ -1,5 +1,5 @@
 // ChatForYou Electron Configuration
-// Auto-generated from web config on 2025-08-05T13:48:28.064Z
+// Auto-generated from web config on 2025-08-08T12:05:06.310Z
 
 window.__CONFIG__ = {
   "API_BASE_URL": "https://hjproject.kro.kr/chatforyou/api",
@@ -13,7 +13,7 @@ window.__CONFIG__ = {
   "APP_VERSION": "1.0.0",
   "PLATFORM_TYPE": "desktop",
   "CONVERTED_FROM": "web",
-  "CONVERSION_DATE": "2025-08-05T13:48:28.064Z"
+  "CONVERSION_DATE": "2025-08-08T12:05:06.310Z"
 };
 
 // Electron specific utilities

--- a/chatforyou-desktop/src/config/config.prod.js
+++ b/chatforyou-desktop/src/config/config.prod.js
@@ -1,5 +1,5 @@
 // ChatForYou Electron Configuration
-// Auto-generated from web config on 2025-08-08T12:05:06.310Z
+// Auto-generated from web config on 2025-08-09T13:42:11.661Z
 
 window.__CONFIG__ = {
   "API_BASE_URL": "https://hjproject.kro.kr/chatforyou/api",
@@ -10,10 +10,10 @@ window.__CONFIG__ = {
   "AUTO_UPDATER": true,
   "WEB_BASE_URL": "https://hjproject.kro.kr/chatforyou",
   "ELECTRON_VERSION": "unknown",
-  "APP_VERSION": "1.0.0",
+  "APP_VERSION": "1.0.2",
   "PLATFORM_TYPE": "desktop",
   "CONVERTED_FROM": "web",
-  "CONVERSION_DATE": "2025-08-08T12:05:06.310Z"
+  "CONVERSION_DATE": "2025-08-09T13:42:11.661Z"
 };
 
 // Electron specific utilities

--- a/chatforyou-desktop/src/main/electron-main.js
+++ b/chatforyou-desktop/src/main/electron-main.js
@@ -59,7 +59,7 @@ function isValidLocalPath(fileUrl) {
             return false;
         }
         
-        // Directory traversal 공격 차단 - 더 정확한 검사
+        // Directory traversal 공격 차단
         const relativePath = path.relative(appDir, normalizedPath);
         if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
             log.warn(`보안: 경로 탐색 시도 차단: ${relativePath}`);
@@ -127,18 +127,34 @@ function setupAutoUpdater() {
         // Mac에서 autoUpdater 이벤트 처리 - 수동 다운로드로 유도
         autoUpdater.on('update-available', (info) => {
             log.info(`Mac 업데이트 발견: v${info.version}`);
+            
+            if (mainWindow) {
+                mainWindow.hide();
+                log.info('Mac 강제 업데이트: 메인 창 숨김');
+            }
+            
             dialog.showMessageBox(mainWindow, {
                 type: 'info',
-                title: '새 버전 업데이트 안내',
-                message: `ChatForYou v${info.version} 업데이트가 있습니다!`,
-                detail: `Mac 버전은 수동 설치가 필요합니다.\nGitHub에서 최신 DMG 파일을 다운로드해주세요.`,
-                buttons: ['GitHub에서 다운로드', '나중에'],
+                title: '필수 업데이트 안내',
+                message: `ChatForYou v${info.version} 필수 업데이트가 있습니다!`,
+                detail: `서비스 사용을 위해 업데이트가 필요합니다.\nGitHub에서 최신 DMG 파일을 다운로드해주세요.`,
+                buttons: ['GitHub에서 다운로드', '나중에 업데이트(앱 종료)'],
                 defaultId: 0,
-                cancelId: 1
+                cancelId: 1,
+                noLink: true  // 링크 스타일 방지
             }).then(result => {
                 if (result.response === 0) {
                     shell.openExternal('https://github.com/SeJonJ/ChatForYou/releases/latest');
-                    log.info('Mac 수동 업데이트: GitHub Releases 페이지 열기');
+                    log.info('Mac 강제 업데이트: GitHub Releases 페이지 열기');
+                    // GitHub 페이지 열기 후에도 앱 종료
+                    setTimeout(() => {
+                        log.info('Mac 강제 업데이트: GitHub 페이지 열기 후 앱 종료');
+                        app.quit();
+                    }, 1000);
+                } else {
+                    // "앱 종료" 선택 시 즉시 종료
+                    log.info('Mac 강제 업데이트: 사용자가 앱 종료 선택');
+                    app.quit();
                 }
             });
         });
@@ -591,6 +607,9 @@ app.whenReady().then(() => {
     setupAutoUpdater();
     
     if (!isDev) {
+        if (process.platform === 'darwin') {
+            log.info('Mac 앱 시작: 강제 업데이트 체크 수행 (재시작 시에도 동일하게 적용)');
+        }
         autoUpdater.checkForUpdatesAndNotify();
         log.info('자동 업데이트 확인 시작');
     }


### PR DESCRIPTION
1. window 및 mac 버전 자동 업데이트 체크 시 뜨는 팝업창에서 '나중에' 버튼 클릭 시 전체 프로그램 종료(일종의 강제 업데이트 로직)
2. window 버전에서 자동 업데이트 팝업에서 MenuBar hide 처리

## Sourcery 요약

팝업 닫기 컨트롤을 비활성화하고 사용자가 업데이트를 미룰 때 앱이 종료되도록 하여 강제 업데이트를 적용합니다. 강제 업데이트 흐름을 반영하도록 UI 레이블을 업데이트하고 Windows에서 메뉴 바를 숨깁니다.

버그 수정:
- 창 닫기 기능을 비활성화하여 닫기 버튼을 통해 강제 업데이트를 무시하는 것을 방지합니다.
- 업데이트를 적용하기 위해 "나중에" 버튼을 클릭할 때도 앱이 종료되도록 합니다.

개선 사항:
- 업데이트가 있을 때 Mac에서 메인 애플리케이션 창을 자동으로 숨깁니다.
- UI를 간소화하기 위해 Windows의 업데이트 팝업에서 메뉴 바를 자동으로 숨깁니다.

기타 작업:
- 패키지 및 설정 파일에서 데스크톱 앱 버전을 1.0.2로 올립니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce mandatory updates by disabling the popup close controls and ensuring the app quits when the user defers; update UI labels to reflect the forced update flow and hide the menu bar on Windows.

Bug Fixes:
- Prevent ignoring mandatory updates via the close button by disabling window closability
- Ensure clicking the “later” button also terminates the app exit to enforce update

Enhancements:
- Automatically hide the main application window on Mac when an update is available
- Auto-hide the menu bar in the update popup on Windows to streamline the UI

Chores:
- Bump desktop app version to 1.0.2 in package and config files

</details>