### PR TITLE
#98 URL을 통해 비밀번호가 걸려있는 방 접근을 막기 위한 jwt 토큰 로직 추가

### DIFF
--- a/nodejs-frontend/static/js/common/ajaxUtil.js
+++ b/nodejs-frontend/static/js/common/ajaxUtil.js
@@ -58,6 +58,14 @@ function ajaxToJson(url, method, async, data, successCallback, errorCallback, co
 }
 
 function tokenAjax(url, method, async, data, successCallback, errorCallback, completeCallback) {
+    var headers = {
+        'Authorization': localStorage.getItem('access_token') || ''
+    };
+
+    var roomToken = sessionStorage.getItem('roomAccessToken');
+    if (roomToken) {
+        headers['X-Room-Token'] = roomToken;
+    }
     $.ajax({
         url: url,
         type: method,
@@ -66,9 +74,7 @@ function tokenAjax(url, method, async, data, successCallback, errorCallback, com
         xhrFields: {
             withCredentials: true
         },
-        headers: {
-            'Authorization': localStorage.getItem('access_token') || ''
-        },
+        headers: headers,
         success: function (data) {
             if (successCallback && typeof successCallback === 'function') {
                 successCallback(data);

--- a/nodejs-frontend/static/js/popup/room_popup.js
+++ b/nodejs-frontend/static/js/popup/room_popup.js
@@ -192,7 +192,9 @@ const RoomPopup = {
         }
 
         let successCallback = function(result) {
-            if (result?.data && result?.result === 'success') {
+            if (result?.data?.isValidate === true) {
+                var roomToken = result.data.token;
+                sessionStorage.setItem('roomAccessToken', roomToken);
                 self.showToast('방에 정상적으로 입장했습니다!', 'success');
                 $('#enterRoomModal').modal('hide');
 

--- a/nodejs-frontend/static/js/popup/room_settings_popup.js
+++ b/nodejs-frontend/static/js/popup/room_settings_popup.js
@@ -162,6 +162,10 @@ const RoomSettingsPopup = {
 
         let successCallback = function (result) {
             if (result && result.result === 'success' && result.data) {
+                var roomToken = result.data.token;
+                if (roomToken) {
+                    sessionStorage.setItem('roomAccessToken', roomToken);
+                }
                 self.loadRoomInfo();
             } else {
                 self.showToast('비밀번호가 일치하지 않습니다.', 'error');

--- a/nodejs-frontend/static/js/rtc/kurento-service.js
+++ b/nodejs-frontend/static/js/rtc/kurento-service.js
@@ -281,6 +281,9 @@ function register() {
             if (error?.responseJSON && ['40050', '40051', '40052'].includes(error.responseJSON.code)) {
                 self.showToast('로그인이 필요한 서비스입니다.');
                 window.location.href = window.__CONFIG__.BASE_URL + '/login/chatlogin.html';
+            } else if (error?.responseJSON && '40061' === error.responseJSON.code) {
+                alert("입장 정보가 확인되지 않았습니다. 다시 시도해주세요.")
+                window.location.href = window.__CONFIG__.BASE_URL + '/roomlist.html';
             }
         };
         // AJAX 요청 실행

--- a/springboot-backend/src/main/java/webChat/config/SslConfig.java
+++ b/springboot-backend/src/main/java/webChat/config/SslConfig.java
@@ -54,7 +54,7 @@ public class SslConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000", "https://hjproject.kro.kr:8653", "https://hjproject.kro.kr/chatforyou")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("Authorization", "Content-Type", "X-Requested-With")
+                .allowedHeaders("Authorization", "Content-Type", "X-Requested-With", "X-Room-Token")
                 .exposedHeaders("Custom-Header")
                 .allowCredentials(true)
                 .maxAge(3600);

--- a/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
+++ b/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
@@ -21,6 +21,7 @@ import webChat.model.room.in.ChatRoomInVo;
 import webChat.model.room.out.ChatRoomOutVo;
 import webChat.model.chat.ChatType;
 import webChat.model.user.UserDto;
+import webChat.security.jwt.JwtRoomProvider;
 import webChat.service.chatroom.ChatRoomService;
 import webChat.service.redis.RedisService;
 import webChat.service.routing.RoutingInstanceProvider;
@@ -43,6 +44,7 @@ public class ChatRoomController {
     private final RoutingInstanceProvider instanceProvider;
     private final RedisService redisService;
     private final UserService userService;
+    private final JwtRoomProvider jwtRoomProvider;
 
     // 채팅방 생성
     @PostMapping("/room")
@@ -82,6 +84,7 @@ public class ChatRoomController {
     public ResponseEntity<ChatForYouResponse> joinRoom(
             @PathVariable String roomId,
             @RequestHeader("Authorization") String authorization,
+            @RequestHeader(value = "X-Room-Token", required = false) String roomToken,
             HttpServletRequest request,
             HttpServletResponse response) throws Exception {
 
@@ -94,6 +97,11 @@ public class ChatRoomController {
         }
 
         ChatRoom chatRoom = chatRoomService.findRoomById(roomId);
+
+        // JWT 토큰 검증
+        if (chatRoom.isSecretChk()) {
+            jwtRoomProvider.validate(roomToken, chatRoom.getRoomId());
+        }
 
         if (StringUtil.isNullOrEmpty(chatRoom.getInstanceId()) || !instanceProvider.isHealthy(chatRoom.getInstanceId())){
             // TODO 서버가 죽었을때 예외처리 필요 :: 방 삭제 및 임시 조치로 메인 대시보드로 이동
@@ -163,7 +171,7 @@ public class ChatRoomController {
         // TODO 추후 401 권한 에러로 수정할 것
         return ResponseEntity.ok(ChatForYouResponse.builder()
                 .result("success")
-                .data(chatRoomService.validatePwd(roomId, roomPwd))
+                .data(chatRoomService.validatePwd(oauthRedis.getEmail(), roomId, roomPwd))
                 .build());
     }
 

--- a/springboot-backend/src/main/java/webChat/controller/ExceptionController.java
+++ b/springboot-backend/src/main/java/webChat/controller/ExceptionController.java
@@ -276,4 +276,20 @@ public class ExceptionController {
         result.put("message", "QR Session Expired");
         return result;
     }
+
+    public static class InvalidRoomAccessException extends BadRequestException {
+        public InvalidRoomAccessException(String message) {
+            super(message);
+        }
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(InvalidRoomAccessException.class)
+    @ResponseBody
+    public Map<String, Object> handleInvalidRoomAccess() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", "40061");
+        result.put("message", "Invalid or missing room access token");
+        return result;
+    }
 }

--- a/springboot-backend/src/main/java/webChat/security/jwt/JwtRoomProvider.java
+++ b/springboot-backend/src/main/java/webChat/security/jwt/JwtRoomProvider.java
@@ -1,0 +1,57 @@
+package webChat.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import webChat.controller.ExceptionController;
+import webChat.security.jwt.core.JwtCoreProvider;
+import webChat.utils.StringUtil;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtRoomProvider {
+    private static final long EXPIRE_MS = 1000L * 60 * 30;
+
+    private final JwtCoreProvider jwtCore;
+
+    public JwtRoomProvider(@Qualifier("roomJwtKey") Key key) {
+        this.jwtCore = new JwtCoreProvider(key);
+    }
+
+    public String create(String roomId, String userId) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("roomId", roomId);
+        claims.put("type", JwtTokenType.ROOM_ACCESS);
+
+        return jwtCore.create(userId, claims, EXPIRE_MS);
+    }
+
+    public void validate(String token, String roomId) throws ExceptionController.InvalidRoomAccessException {
+        try {
+            if (StringUtil.isNullOrEmpty(token)) {
+                throw new ExceptionController.InvalidRoomAccessException("Invalid access");
+            }
+            Claims claims = jwtCore.parse(token);
+
+            if (!JwtTokenType.ROOM_ACCESS.name().equals(claims.get("type"))) {
+                throw new ExceptionController.InvalidRoomAccessException("Invalid room access info");
+            }
+
+            String tokenRoomId = claims.get("roomId", String.class);
+            if (!roomId.equals(tokenRoomId)) {
+                throw new ExceptionController.InvalidRoomAccessException("Invalid room access info");
+            }
+        } catch (Exception e) {
+            throw new ExceptionController.InvalidRoomAccessException("Invalid access");
+        }
+    }
+}

--- a/springboot-backend/src/main/java/webChat/security/jwt/JwtRoomProvider.java
+++ b/springboot-backend/src/main/java/webChat/security/jwt/JwtRoomProvider.java
@@ -19,12 +19,15 @@ import java.util.Map;
 
 @Component
 public class JwtRoomProvider {
-    private static final long EXPIRE_MS = 1000L * 60 * 30;
-
+    private final long EXPIRE_MS;
     private final JwtCoreProvider jwtCore;
 
-    public JwtRoomProvider(@Qualifier("roomJwtKey") Key key) {
+    public JwtRoomProvider(
+            @Qualifier("roomJwtKey") Key key,
+            @Value("${jwt.room.expire-ms:1800000}") long expireMs
+    ) {
         this.jwtCore = new JwtCoreProvider(key);
+        this.EXPIRE_MS = expireMs;
     }
 
     public String create(String roomId, String userId) {

--- a/springboot-backend/src/main/java/webChat/security/jwt/JwtTokenType.java
+++ b/springboot-backend/src/main/java/webChat/security/jwt/JwtTokenType.java
@@ -1,0 +1,5 @@
+package webChat.security.jwt;
+
+public enum JwtTokenType {
+    ROOM_ACCESS
+}

--- a/springboot-backend/src/main/java/webChat/security/jwt/config/JwtKeyConfig.java
+++ b/springboot-backend/src/main/java/webChat/security/jwt/config/JwtKeyConfig.java
@@ -1,0 +1,23 @@
+package webChat.security.jwt.config;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import java.security.Key;
+
+@Configuration
+public class JwtKeyConfig {
+
+    @Bean
+    @Qualifier("roomJwtKey")
+    public Key roomJwtKey(
+            @Value("${jwt.room.secret}") String secret
+    ) {
+        return Keys.hmacShaKeyFor(
+                Decoders.BASE64.decode(secret)
+        );
+    }
+}

--- a/springboot-backend/src/main/java/webChat/security/jwt/core/JwtCoreProvider.java
+++ b/springboot-backend/src/main/java/webChat/security/jwt/core/JwtCoreProvider.java
@@ -1,0 +1,39 @@
+package webChat.security.jwt.core;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtCoreProvider {
+
+    private final Key key;
+
+    public JwtCoreProvider(Key key) {
+        this.key = key;
+    }
+
+    public String create(String subject, Map<String, Object> claims, long expireMs) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .addClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expireMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims parse(String token) {
+        return Jwts.parser()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}
+

--- a/springboot-backend/src/main/java/webChat/service/chatroom/ChatRoomService.java
+++ b/springboot-backend/src/main/java/webChat/service/chatroom/ChatRoomService.java
@@ -18,6 +18,7 @@ import webChat.model.room.ChatRoom;
 import webChat.model.room.KurentoRoom;
 import webChat.model.room.RoomState;
 import webChat.model.room.in.ChatRoomInVo;
+import webChat.security.jwt.JwtRoomProvider;
 import webChat.service.analysis.AnalysisService;
 import webChat.service.file.FileService;
 import webChat.service.kafka.ChatKafkaProducer;
@@ -49,6 +50,8 @@ public class ChatRoomService {
     private final RoutingService routingService;
 
     private final ChatKafkaProducer chatKafkaProducer;
+
+    private final JwtRoomProvider jwtRoomProvider;
 
     @Value("${chatforyou.room.max_user_count}")
     private int MAX_USER_COUNT;
@@ -134,16 +137,23 @@ public class ChatRoomService {
     }
 
     // 채팅방 비밀번호 조회
-    public boolean validatePwd(String roomId, String roomPwd) throws BadRequestException {
+    public Map<String, Object> validatePwd(String email, String roomId, String roomPwd) throws BadRequestException {
+        Map<String, Object> result = new HashMap<>();
         ChatRoom chatRoom = redisService.getRedisDataByDataType(roomId, DataType.CHATROOM, KurentoRoom.class);
         if(chatRoom == null) {
             // TODO 방정보 찾을 수 없는 경우 예외처리
         }
-
         boolean validPwd = chatRoom.getRoomPwd().equals(roomPwd);
         boolean overUserCnt = chatRoom.getUserCount() + 1 > chatRoom.getMaxUserCnt();
+        boolean isValidate = validPwd && !overUserCnt;
+        result.put("isValidate", isValidate);
 
-        return validPwd && !overUserCnt;
+        // jwt 토큰 발급
+        if (isValidate) {
+            String token = jwtRoomProvider.create(chatRoom.getRoomId(), email);
+            result.put("token", token);
+        }
+        return result;
     }
 
     // maxUserCnt 에 따른 채팅방 입장 여부


### PR DESCRIPTION
비밀번호를 입력하여 정상적으로 방 입장 시에 JWT 토큰을 발급하여 관리하도록 하였습니다.
비정상적인 루트인 url를 통해 방 입장 시도 시 토큰을 확인하여 유효성 검사 로직을 추가하였습니다.

## Summary by Sourcery

비밀번호로 보호되는 채팅방에 안전하게 입장할 수 있도록 JWT 기반의 방 액세스 토큰을 추가하고, 방 참가 요청 시 액세스를 검증합니다.

New Features:
- 사용자가 비밀 채팅방의 비밀번호를 성공적으로 검증했을 때, 단기간만 유효한 JWT 방 액세스 토큰을 발급합니다.
- 비밀 방에 참가할 때, AJAX 요청에 `X-Room-Token` 헤더를 통해 방별 액세스 토큰을 포함하고 이를 검증합니다.

Enhancements:
- 방 액세스 토큰을 위해 전용 JWT 코어 프로바이더와 키 설정을 도입합니다.
- 잘못되었거나 누락된 방 액세스 토큰을 전용 예외로 처리하고, 표준화된 에러 응답 코드 `40061`을 사용합니다.
- 사용자 정의 헤더 `X-Room-Token`을 허용하도록 CORS 구성을 확장합니다.
- 프런트엔드 방 입장 플로우를 업데이트하여 방 액세스 토큰을 저장·전파·처리하고, 토큰이 유효하지 않을 경우 사용자에게 리다이렉트 동작을 수행합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add JWT-based room access tokens to secure entry into password-protected chat rooms and validate access on room join requests.

New Features:
- Issue short-lived JWT room access tokens when a user successfully validates a password for a secret chat room.
- Include a per-room access token in AJAX requests via an X-Room-Token header and validate it on room join for secret rooms.

Enhancements:
- Introduce a shared JWT core provider and key configuration specifically for room access tokens.
- Handle invalid or missing room access tokens with a dedicated exception and standardized error response code 40061.
- Extend CORS configuration to allow the custom X-Room-Token header.
- Update front-end room entry flows to store, propagate, and react to room access tokens, redirecting users when tokens are invalid.

</details>