### PR TITLE
Hotfix/1

### DIFF
--- a/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
+++ b/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
@@ -56,7 +56,7 @@ public class ChatRoomController {
 
         // token 확인
         FirebaseToken token = TokenUtils.checkGoogleOAuthToken(authorization);
-        OauthRedis oauthRedis = redisService.getRedisDataByDataType(token.getEmail(), DataType.SOCIAL_USER, OauthRedis.class);
+        OauthRedis oauthRedis = userService.getFriendRedisInfo(token.getEmail(), OauthRedis.class);
 
         if (oauthRedis == null) {
             throw new ExceptionController.NotExistUserException("");
@@ -90,7 +90,7 @@ public class ChatRoomController {
 
         // token 확인
         FirebaseToken token = TokenUtils.checkGoogleOAuthToken(authorization);
-        OauthRedis oauthRedis = redisService.getRedisDataByDataType(token.getEmail(), DataType.SOCIAL_USER, OauthRedis.class);
+        OauthRedis oauthRedis = userService.getFriendRedisInfo(token.getEmail(), OauthRedis.class);
 
         if (oauthRedis == null) {
             throw new ExceptionController.NotExistUserException("");

--- a/springboot-backend/src/main/java/webChat/entity/SocialUser.java
+++ b/springboot-backend/src/main/java/webChat/entity/SocialUser.java
@@ -12,6 +12,9 @@ import lombok.*;
 @Builder
 public class SocialUser {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long idx;
+    @Column
     private String email;
     @Column
     private String nickname;

--- a/springboot-backend/src/main/java/webChat/model/login/OauthRedis.java
+++ b/springboot-backend/src/main/java/webChat/model/login/OauthRedis.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class OauthRedis {
+    private long idx;
     private String email;
     private String accessToken;
     private String refreshToken;

--- a/springboot-backend/src/main/java/webChat/model/redis/RedisKeyPrefix.java
+++ b/springboot-backend/src/main/java/webChat/model/redis/RedisKeyPrefix.java
@@ -8,7 +8,6 @@ public enum RedisKeyPrefix {
     ROOM_ID_PREFIX("roomId:"),
     USER_ID_PREFIX("userId:"),
     USER_PREFIX("user:"),
-    SOCIAL_USER_PREFIX("oauth:"),
     ROOM_ROUTING_PREFIX("room:mapping:"),
     ROOM_COUNT_PREFIX("instance:roomcount:"),
     INSTANCE_HEARTBEAT_PREFIX("instance:heartbeat:"),

--- a/springboot-backend/src/main/java/webChat/service/login/impl/LoginServiceImpl.java
+++ b/springboot-backend/src/main/java/webChat/service/login/impl/LoginServiceImpl.java
@@ -83,6 +83,7 @@ public class LoginServiceImpl implements LoginService {
 
         // 레디스 insert
         OauthRedis oauthRedis = new OauthRedis();
+        oauthRedis.setIdx(socialUser.getIdx());
         oauthRedis.setEmail(socialUser.getEmail());
         oauthRedis.setAccessToken(accessToken);
         oauthRedis.setRefreshToken(refreshToken);
@@ -103,8 +104,12 @@ public class LoginServiceImpl implements LoginService {
 
     @Override
     public void logout(String authorization, String email) throws Exception{
+        SocialUser user = socialUserRepository.findByEmail(email);
+        if (user == null) {
+            throw new BadRequestException("Not exist user !!!");
+        }
         // 레디스에서 삭제
-        redisService.deleteLoginInfo(email);
+        redisService.deleteLoginInfo(user.getIdx());
     }
 
     @Override

--- a/springboot-backend/src/main/java/webChat/service/redis/RedisService.java
+++ b/springboot-backend/src/main/java/webChat/service/redis/RedisService.java
@@ -81,7 +81,7 @@ public interface RedisService {
 
     Map<String, String> getAllInstanceCookies() throws BadRequestException;
     void insertGoogleOauthToken(OauthRedis oauthRedis, long time);
-    void deleteLoginInfo(String email);
+    void deleteLoginInfo(long idx);
     void insertQRSession(QRSession qrSession);
     QRSession getQRSession(String sessionId);
 }

--- a/springboot-backend/src/main/java/webChat/service/redis/impl/RedisServiceImpl.java
+++ b/springboot-backend/src/main/java/webChat/service/redis/impl/RedisServiceImpl.java
@@ -342,7 +342,7 @@ public class RedisServiceImpl implements RedisService {
         if (DataType.LOGIN_USER.equals(dataType) || DataType.USER_REFRESH_TOKEN.equals(dataType) || DataType.USER_LAST_LOGIN_DATE.equals(dataType)) {
             redisKey = key.contains("user:") ? key : "user:" + key;
         } else if (DataType.SOCIAL_USER.equals(dataType)) {
-            redisKey = SOCIAL_USER_PREFIX.getPrefix() + key;
+            redisKey = OAUTH_PREFIX.getPrefix() + key;
         } else {
             redisKey = makeRedisKey(key);
         }
@@ -539,16 +539,17 @@ public class RedisServiceImpl implements RedisService {
 
     @Override
     public void insertGoogleOauthToken(OauthRedis oauthRedis, long time) {
-        String redisKey = OAUTH_PREFIX.getPrefix() + oauthRedis.getEmail();
+        String redisKey = OAUTH_PREFIX.getPrefix() + oauthRedis.getIdx();
         masterTemplate.opsForHash().put(redisKey, DataType.SOCIAL_USER.getType(), oauthRedis);
+        masterTemplate.opsForHash().put(redisKey, "idx", oauthRedis.getIdx());
         masterTemplate.opsForHash().put(redisKey, "email", oauthRedis.getEmail());
         masterTemplate.opsForHash().put(redisKey, "nickname", oauthRedis.getEmail().split("@")[0]);
         masterTemplate.opsForHash().put(redisKey, "lastLoginDate", time);
     }
 
     @Override
-    public void deleteLoginInfo(String email) {
-        masterTemplate.delete(SOCIAL_USER_PREFIX.getPrefix() + email);
+    public void deleteLoginInfo(long idx) {
+        masterTemplate.delete(OAUTH_PREFIX.getPrefix() + idx);
     }
 
     @Override

--- a/springboot-backend/src/main/java/webChat/service/user/UserService.java
+++ b/springboot-backend/src/main/java/webChat/service/user/UserService.java
@@ -1,8 +1,10 @@
 package webChat.service.user;
 
 import webChat.model.login.OauthRedis;
+import webChat.model.redis.DataType;
 import webChat.model.user.UserDto;
 
 public interface UserService {
     UserDto getUserInfo(OauthRedis oauthRedis) throws Exception;
+    <T> T getFriendRedisInfo(String userId, Class<T> clazz) throws Exception;
 }

--- a/springboot-backend/src/main/java/webChat/service/user/impl/UserServiceImpl.java
+++ b/springboot-backend/src/main/java/webChat/service/user/impl/UserServiceImpl.java
@@ -3,20 +3,25 @@ package webChat.service.user.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import webChat.entity.SocialUser;
 import webChat.model.login.OauthRedis;
+import webChat.model.redis.DataType;
 import webChat.model.user.UserDto;
 import webChat.repository.SocialUserRepository;
 import webChat.service.user.UserService;
 
 import java.util.Optional;
 
+import static webChat.model.redis.RedisKeyPrefix.*;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
     private final SocialUserRepository socialUserRepository;
+    private final RedisTemplate<String, Object> slaveTemplate;
 
     @Override
     public UserDto getUserInfo(OauthRedis oauthRedis) throws Exception {
@@ -28,5 +33,16 @@ public class UserServiceImpl implements UserService {
 
         return UserDto.of(socialUser.get(), oauthRedis);
 
+    }
+
+    @Override
+    public <T> T getFriendRedisInfo(String userId, Class<T> clazz) throws Exception {
+        SocialUser user = socialUserRepository.findByEmail(userId);
+        if (user == null) {
+            throw new RuntimeException("Not exist user !!!");
+        }
+
+        String redisKey = OAUTH_PREFIX.getPrefix() + user.getIdx();
+        return clazz.cast(slaveTemplate.opsForHash().get(redisKey, DataType.SOCIAL_USER.getType()));
     }
 }


### PR DESCRIPTION
social_user 테이블 스키마 변경

- 스키마 변경에 따른 레디스 prefix 수정
- 유저 정보 관련 레디스 로직 수정
- 방 생성, 방 입장 레디스 조회 로직 수정

## Summary by Sourcery

소셜 사용자 식별 방식을 이메일 기반에서 기본 키(Primary Key) 기반으로 업데이트하고, 새로운 스키마에 맞게 Redis 사용 방식과 채팅 플로우를 정렬합니다.

버그 수정:
- 스키마 변경 이후에도 로그아웃 및 채팅방 플로우가 Redis에서 소셜 사용자를 올바르게 조회하도록 보장합니다.

개선 사항:
- `SocialUser`에 숫자 기본 키 필드를 추가하고, 이를 OAuth Redis 모델과 로그인 플로우 전반에 전파합니다.
- 소셜 사용자 OAuth 데이터를 위한 Redis 키 전략을 이메일 대신 사용자 인덱스에 `OAUTH` 접두사를 사용하도록 변경하고, 사용이 중단된 `SOCIAL_USER_PREFIX`를 제거합니다.
- 사용자, Redis, 채팅방 서비스가 이메일 대신 소셜 사용자 인덱스를 사용해 OAuth/세션 데이터를 조회 및 삭제하도록 조정합니다.
- 이메일에 연결된 소셜 사용자 인덱스를 통해 OAuth Redis 정보를 가져오는 사용자 서비스 헬퍼를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update social user identification from email-based to primary-key-based and align Redis usage and chat flows with the new schema.

Bug Fixes:
- Ensure logout and chat room flows correctly resolve social users from Redis after schema change.

Enhancements:
- Add numeric primary key field to SocialUser and propagate it through OAuth Redis model and login flow.
- Change Redis key strategy for social user OAuth data to use the user index with the OAUTH prefix instead of email and remove the deprecated SOCIAL_USER_PREFIX.
- Adjust user, Redis, and chat room services to look up and delete OAuth/session data using the social user index rather than email.
- Introduce a user service helper to fetch OAuth Redis info by email via the associated social user index.

</details>