### PR TITLE
#102 로그인 된 유저가 방 수정 및 삭제 불가능한 버그 :: 유저 검증 및 로그인 검증

### DIFF
--- a/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
+++ b/springboot-backend/src/main/java/webChat/controller/ChatRoomController.java
@@ -23,6 +23,7 @@ import webChat.model.chat.ChatType;
 import webChat.model.user.UserDto;
 import webChat.security.jwt.JwtRoomProvider;
 import webChat.service.chatroom.ChatRoomService;
+import webChat.service.login.LoginService;
 import webChat.service.redis.RedisService;
 import webChat.service.routing.RoutingInstanceProvider;
 import webChat.service.routing.RoutingService;
@@ -42,7 +43,6 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
     private final RoutingService routingService;
     private final RoutingInstanceProvider instanceProvider;
-    private final RedisService redisService;
     private final UserService userService;
     private final JwtRoomProvider jwtRoomProvider;
 
@@ -56,11 +56,8 @@ public class ChatRoomController {
 
         // token 확인
         FirebaseToken token = TokenUtils.checkGoogleOAuthToken(authorization);
-        OauthRedis oauthRedis = userService.getFriendRedisInfo(token.getEmail(), OauthRedis.class);
-
-        if (oauthRedis == null) {
-            throw new ExceptionController.NotExistUserException("");
-        }
+        // 유저 검증 및 로그인(레디스 저장) 정보 확인
+        userService.getValidatedOauthUser(token.getEmail());
 
         String roomId = routingService.getCookie(request, RoutingCookie.ROOM_ID_COOKIE);
         // 매개변수 : 방 이름, 패스워드, 방 잠금 여부, 방 인원수
@@ -90,14 +87,10 @@ public class ChatRoomController {
 
         // token 확인
         FirebaseToken token = TokenUtils.checkGoogleOAuthToken(authorization);
-        OauthRedis oauthRedis = userService.getFriendRedisInfo(token.getEmail(), OauthRedis.class);
-
-        if (oauthRedis == null) {
-            throw new ExceptionController.NotExistUserException("");
-        }
+        // 유저 검증 및 로그인(레디스 저장) 정보 확인
+        OauthRedis oauthRedis = userService.getValidatedOauthUser(token.getEmail());
 
         ChatRoom chatRoom = chatRoomService.findRoomById(roomId);
-
         // JWT 토큰 검증
         if (chatRoom.isSecretChk()) {
             jwtRoomProvider.validate(roomToken, chatRoom.getRoomId());
@@ -136,16 +129,6 @@ public class ChatRoomController {
             @RequestParam(value = "pageNum", required = false, defaultValue = "0") String pageNumStr,
             @RequestParam(value = "pageSize", required = false, defaultValue = "20") String pageSizeStr){
         List<ChatRoomOutVo> responses = new ArrayList<>();
-
-        // TODO 로그인 기능 도입 시 필요
-//        // principalDetails 가 null 이 아니라면 로그인 된 상태!!
-//        if (principalDetails != null) {
-//            // 세션에서 로그인 유저 정보를 가져옴
-//            model.addAttribute("user", principalDetails.getUser());
-//            log.debug("user [{}] ",principalDetails);
-//        }
-
-//        model.addAttribute("user", "hey");
         chatRoomService.getRoomList(keyword, Integer.parseInt(pageNumStr), Integer.parseInt(pageSizeStr), false).forEach(room -> {
             responses.add(ChatRoomOutVo.of(room));
         });
@@ -160,11 +143,7 @@ public class ChatRoomController {
             @RequestHeader("Authorization") String authorization) throws Exception {
 
         FirebaseToken token = TokenUtils.checkGoogleOAuthToken(authorization);
-        OauthRedis oauthRedis = redisService.getRedisDataByDataType(token.getEmail(), DataType.SOCIAL_USER, OauthRedis.class);
-
-        if (oauthRedis == null) {
-            throw new ExceptionController.NotExistUserException("");
-        }
+        OauthRedis oauthRedis = userService.getValidatedOauthUser(token.getEmail());
 
         // 넘어온 roomId 와 roomPwd 를 이용해서 비밀번호 찾기
         // 찾아서 입력받은 roomPwd 와 room pwd 와 비교해서 맞으면 true, 아니면  false
@@ -179,7 +158,11 @@ public class ChatRoomController {
     @PutMapping(value = "/room/{roomId}")
     public ResponseEntity<ChatForYouResponse> modifyChatRoom(
             @PathVariable String roomId,
-            @RequestBody ChatRoomInVo chatRoom) throws BadRequestException {
+            @RequestHeader("Authorization") String authorization,
+            @RequestBody ChatRoomInVo chatRoom) throws Exception {
+
+        FirebaseToken token = TokenUtils.checkGoogleOAuthToken(authorization);
+        userService.getValidatedOauthUser(token.getEmail());
         return ResponseEntity.ok(ChatForYouResponse.builder()
                 .result("success")
                 .data(chatRoomService.updateRoom(roomId, chatRoom.getRoomName(), chatRoom.getRoomPwd(), chatRoom.getMaxUserCnt()))
@@ -188,8 +171,12 @@ public class ChatRoomController {
 
     // 채팅방 삭제
     @DeleteMapping("/room/{roomId}")
-    public ResponseEntity<ChatForYouResponse> delChatRoom(@PathVariable String roomId) throws BadRequestException, ExceptionController.DelRoomException {
-
+    public ResponseEntity<ChatForYouResponse> delChatRoom(
+            @PathVariable String roomId,
+            @RequestHeader("Authorization") String authorization) throws Exception {
+        FirebaseToken token = TokenUtils.checkGoogleOAuthToken(authorization);
+        // 유저 검증 및 로그인(레디스 저장) 정보 확인
+        userService.getValidatedOauthUser(token.getEmail());
         // roomId 기준으로 chatRoomMap 에서 삭제, 해당 채팅룸 안에 있는 사진 삭제
         return ResponseEntity.ok(ChatForYouResponse.builder()
                 .result("success")

--- a/springboot-backend/src/main/java/webChat/model/login/OauthRedis.java
+++ b/springboot-backend/src/main/java/webChat/model/login/OauthRedis.java
@@ -3,6 +3,9 @@ package webChat.model.login;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * 로그인한 유저 정보를 redis 에 저장하기 위한 객체
+ */
 @Getter
 @Setter
 public class OauthRedis {

--- a/springboot-backend/src/main/java/webChat/service/user/UserService.java
+++ b/springboot-backend/src/main/java/webChat/service/user/UserService.java
@@ -1,10 +1,11 @@
 package webChat.service.user;
 
+import org.apache.coyote.BadRequestException;
 import webChat.model.login.OauthRedis;
 import webChat.model.redis.DataType;
 import webChat.model.user.UserDto;
 
 public interface UserService {
     UserDto getUserInfo(OauthRedis oauthRedis) throws Exception;
-    <T> T getFriendRedisInfo(String userId, Class<T> clazz) throws Exception;
+    OauthRedis getValidatedOauthUser(String userId) throws BadRequestException;
 }

--- a/springboot-backend/src/main/java/webChat/service/user/impl/UserServiceImpl.java
+++ b/springboot-backend/src/main/java/webChat/service/user/impl/UserServiceImpl.java
@@ -10,7 +10,9 @@ import webChat.model.login.OauthRedis;
 import webChat.model.redis.DataType;
 import webChat.model.user.UserDto;
 import webChat.repository.SocialUserRepository;
+import webChat.service.redis.RedisService;
 import webChat.service.user.UserService;
+import webChat.utils.StringUtil;
 
 import java.util.Optional;
 
@@ -21,13 +23,13 @@ import static webChat.model.redis.RedisKeyPrefix.*;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
     private final SocialUserRepository socialUserRepository;
-    private final RedisTemplate<String, Object> slaveTemplate;
+    private final RedisService redisService;
 
     @Override
     public UserDto getUserInfo(OauthRedis oauthRedis) throws Exception {
         Optional<SocialUser> socialUser = Optional.ofNullable(socialUserRepository.findByEmail(oauthRedis.getEmail()));
 
-        if(socialUser == null || socialUser.isEmpty()){
+        if(socialUser.isEmpty()){
             throw new BadRequestException("Not exist user !!!");
         }
 
@@ -35,14 +37,19 @@ public class UserServiceImpl implements UserService {
 
     }
 
+    // TODO 전반적인 예외 처리 수정 필요
     @Override
-    public <T> T getFriendRedisInfo(String userId, Class<T> clazz) throws Exception {
+    public OauthRedis getValidatedOauthUser(String userId) throws BadRequestException {
         SocialUser user = socialUserRepository.findByEmail(userId);
         if (user == null) {
-            throw new RuntimeException("Not exist user !!!");
+            throw new BadRequestException("Not exist user !!!");
         }
 
-        String redisKey = OAUTH_PREFIX.getPrefix() + user.getIdx();
-        return clazz.cast(slaveTemplate.opsForHash().get(redisKey, DataType.SOCIAL_USER.getType()));
+        OauthRedis oauthRedis = redisService.getRedisDataByDataType(String.valueOf(user.getIdx()), DataType.SOCIAL_USER, OauthRedis.class);
+        if (oauthRedis == null) {
+            throw new BadRequestException("Not exist oauth redis !!!");
+        }
+
+        return oauthRedis;
     }
 }


### PR DESCRIPTION
- 로그인 검증은 redis 에 로그인 정보가 저장되어있는지 확인

## Summary by Sourcery

OAuth 사용자와 Redis 세션 검증을 사용자 서비스로 중앙집중화하여, 채팅방 생성, 접근, 수정, 삭제 시 인증되고 검증된 사용자만 허용되도록 강제합니다.

버그 수정:
- 엔드포인트에 권한 체크를 추가하고 사용자 조회 로직을 수정하여, Redis 기반의 유효한 세션을 가진 로그인 사용자들이 채팅방을 수정하고 삭제할 수 있도록 합니다.

개선 사항:
- 사용자 존재 여부와 해당 Redis 로그인 데이터를 모두 검증하는 사용자 서비스의 전용 메서드 `getValidatedOauthUser`로, 여기저기 흩어져 있던 Redis 조회를 대체합니다.
- 로그인 검증을 위해 사용자 서비스를 사용하고 Redis 직접 접근을 제거하여 채팅방 컨트롤러의 의존성을 단순화합니다.
- Redis에 저장된 로그인 사용자 데이터를 표현하는 모델로 OAuth Redis 모델을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce authenticated, validated users for chat room creation, access, modification, and deletion by centralizing OAuth user and Redis session validation in the user service.

Bug Fixes:
- Allow logged-in users with valid Redis-backed sessions to modify and delete chat rooms by adding authorization checks to these endpoints and fixing user lookup logic.

Enhancements:
- Replace scattered Redis lookups with a dedicated getValidatedOauthUser method in the user service that verifies both user existence and corresponding Redis login data.
- Simplify chat room controller dependencies by removing direct Redis access and using the user service for login validation.
- Document the OAuth Redis model as the representation of logged-in user data stored in Redis.

</details>